### PR TITLE
Require all Boxed types to be Send

### DIFF
--- a/src/cipherstate.rs
+++ b/src/cipherstate.rs
@@ -3,13 +3,13 @@ use error::{self, ErrorKind, InitStage};
 use types::Cipher;
 
 pub struct CipherState {
-    cipher : Box<Cipher>,
+    cipher : Box<Cipher + Send>,
     n : u64,
     has_key : bool,
 }
 
 impl CipherState {
-    pub fn new(cipher: Box<Cipher>) -> Self {
+    pub fn new(cipher: Box<Cipher + Send>) -> Self {
         Self {
             cipher: cipher,
             n: 0,

--- a/src/handshakestate.rs
+++ b/src/handshakestate.rs
@@ -16,11 +16,11 @@ use error::{ErrorKind, Result, InitStage, StateProblem};
 ///
 /// See: http://noiseprotocol.org/noise.html#the-handshakestate-object
 pub struct HandshakeState {
-    rng : Box<Random>,
+    rng : Box<Random + Send>,
     symmetricstate : SymmetricState,
     cipherstates: CipherStates,
-    s: Toggle<Box<Dh>>,
-    e: Toggle<Box<Dh>>,
+    s: Toggle<Box<Dh + Send>>,
+    e: Toggle<Box<Dh + Send>>,
     fixed_ephemeral: bool,
     rs: Toggle<[u8; MAXDHLEN]>,
     re: Toggle<[u8; MAXDHLEN]>,
@@ -34,11 +34,11 @@ pub struct HandshakeState {
 impl HandshakeState {
     #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
     pub fn new(
-        rng: Box<Random>,
+        rng: Box<Random + Send>,
         cipherstate: CipherState,
-        hasher: Box<Hash>,
-        s : Toggle<Box<Dh>>,
-        e : Toggle<Box<Dh>>,
+        hasher: Box<Hash + Send>,
+        s : Toggle<Box<Dh + Send>>,
+        e : Toggle<Box<Dh + Send>>,
         fixed_ephemeral: bool,
         rs: Toggle<[u8; MAXDHLEN]>,
         re: Toggle<[u8; MAXDHLEN]>,

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -13,27 +13,27 @@ use error::{ErrorKind, Result, InitStage, Prerequisite};
 
 /// An object that resolves the providers of Noise crypto choices
 pub trait CryptoResolver {
-    fn resolve_rng(&self) -> Option<Box<Random>>;
-    fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<Dh>>;
-    fn resolve_hash(&self, choice: &HashChoice) -> Option<Box<Hash>>;
-    fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<Cipher>>;
+    fn resolve_rng(&self) -> Option<Box<Random + Send>>;
+    fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<Dh + Send>>;
+    fn resolve_hash(&self, choice: &HashChoice) -> Option<Box<Hash + Send>>;
+    fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<Cipher + Send>>;
 }
 
 /// The default pure-rust crypto implementation resolver.
 pub struct DefaultResolver;
 impl CryptoResolver for DefaultResolver {
-    fn resolve_rng(&self) -> Option<Box<Random>> {
+    fn resolve_rng(&self) -> Option<Box<Random + Send>> {
         Some(Box::new(RandomOs::default()))
     }
 
-    fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<Dh>> {
+    fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<Dh + Send>> {
         match *choice {
             DHChoice::Curve25519 => Some(Box::new(Dh25519::default())),
             _                    => None,
         }
     }
 
-    fn resolve_hash(&self, choice: &HashChoice) -> Option<Box<Hash>> {
+    fn resolve_hash(&self, choice: &HashChoice) -> Option<Box<Hash + Send>> {
         match *choice {
             HashChoice::SHA256  => Some(Box::new(HashSHA256::default())),
             HashChoice::SHA512  => Some(Box::new(HashSHA512::default())),
@@ -42,7 +42,7 @@ impl CryptoResolver for DefaultResolver {
         }
     }
 
-    fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<Cipher>> {
+    fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<Cipher + Send>> {
         match *choice {
             CipherChoice::ChaChaPoly => Some(Box::new(CipherChaChaPoly::default())),
             CipherChoice::AESGCM     => Some(Box::new(CipherAESGCM::default())),

--- a/src/symmetricstate.rs
+++ b/src/symmetricstate.rs
@@ -18,14 +18,14 @@ pub trait SymmetricStateType {
 
 pub struct SymmetricState {
     cipherstate : CipherState,
-    hasher: Box<Hash>,
+    hasher: Box<Hash + Send>,
     h : [u8; MAXHASHLEN],
     ck: [u8; MAXHASHLEN],
     has_key: bool,
 }
 
 impl SymmetricState {
-    pub fn new(cipherstate: CipherState, hasher: Box<Hash>) -> SymmetricState
+    pub fn new(cipherstate: CipherState, hasher: Box<Hash + Send>) -> SymmetricState
     {
         SymmetricState {
             cipherstate: cipherstate,

--- a/src/wrappers/ring_wrapper.rs
+++ b/src/wrappers/ring_wrapper.rs
@@ -18,15 +18,15 @@ impl RingAcceleratedResolver {
 
 #[cfg(feature = "ring")]
 impl CryptoResolver for RingAcceleratedResolver {
-    fn resolve_rng(&self) -> Option<Box<Random>> {
+    fn resolve_rng(&self) -> Option<Box<Random + Send>> {
         self.parent.resolve_rng()
     }
 
-    fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<Dh>> {
+    fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<Dh + Send>> {
         self.parent.resolve_dh(choice)
     }
 
-    fn resolve_hash(&self, choice: &HashChoice) -> Option<Box<Hash>> {
+    fn resolve_hash(&self, choice: &HashChoice) -> Option<Box<Hash + Send>> {
         match *choice {
             HashChoice::SHA256 => Some(Box::new(HashSHA256::default())),
             HashChoice::SHA512 => Some(Box::new(HashSHA512::default())),
@@ -34,7 +34,7 @@ impl CryptoResolver for RingAcceleratedResolver {
         }
     }
 
-    fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<Cipher>> {
+    fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<Cipher + Send>> {
         match *choice {
             CipherChoice::AESGCM => Some(Box::new(CipherAESGCM::default())),
             CipherChoice::ChaChaPoly => Some(Box::new(CipherChaChaPoly::default())),

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -61,21 +61,21 @@ impl TestResolver {
 }
 
 impl CryptoResolver for TestResolver {
-    fn resolve_rng(&self) -> Option<Box<Random>> {
+    fn resolve_rng(&self) -> Option<Box<Random + Send>> {
         let mut rng = RandomInc::default();
         rng.next_byte = self.next_byte;
         Some(Box::new(rng))
     }
 
-    fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<Dh>> {
+    fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<Dh + Send>> {
         self.parent.resolve_dh(choice)
     }
 
-    fn resolve_hash(&self, choice: &HashChoice) -> Option<Box<Hash>> {
+    fn resolve_hash(&self, choice: &HashChoice) -> Option<Box<Hash + Send>> {
         self.parent.resolve_hash(choice)
     }
 
-    fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<Cipher>> {
+    fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<Cipher + Send>> {
         self.parent.resolve_cipher(choice)
     }
 }


### PR DESCRIPTION
This enables snow::Session to be sent across threads, for example when spawning
a Future in tokio that uses a Session.