### PR TITLE
Make `Dh` trait return `Result`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,9 @@ pub enum SnowError {
     #[fail(display = "invalid input")]
     Input,
 
+    #[fail(display = "dh failed")]
+    Dh,
+
     #[fail(display = "decryption failed")]
     Decrypt,
 }

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -138,9 +138,10 @@ impl Dh for Dh25519 {
         &self.privkey
     }
 
-    fn dh(&self, pubkey: &[u8], out: &mut [u8]) {
+    fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), ()> {
         let result = x25519::diffie_hellman(&self.privkey, array_ref![pubkey, 0, 32]);
         copy_memory(&result, out);
+        Ok(())
     }
 }
 
@@ -435,7 +436,7 @@ mod tests {
         copy_memory(&scalar, &mut keypair.privkey);
         let public = Vec::<u8>::from_hex("e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c").unwrap();
         let mut output = [0u8; 32];
-        keypair.dh(&public, &mut output);
+        keypair.dh(&public, &mut output).unwrap();
         assert!(hex::encode(output) == "c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552");
     }
 

--- a/src/resolvers/hacl_star.rs
+++ b/src/resolvers/hacl_star.rs
@@ -96,10 +96,11 @@ impl Dh for Dh25519 {
         &self.privkey.0
     }
 
-    fn dh(&self, pubkey: &[u8], out: &mut [u8]) {
+    fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), ()> {
         let out = array_mut_ref!(out, 0, 32);
         let pubkey = array_ref!(pubkey, 0, 32);
         curve25519::scalarmult(out, &self.privkey.0, pubkey);
+        Ok(())
     }
 
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,7 +18,7 @@ pub trait Dh {
     fn generate(&mut self, rng: &mut Random);
     fn pubkey(&self) -> &[u8];
     fn privkey(&self) -> &[u8];
-    fn dh(&self, pubkey: &[u8], out: &mut [u8]);
+    fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), ()>;
 }
 
 /// Provides cipher operations


### PR DESCRIPTION
Some implementations of `Curve25519` may fail (e.g. `sodiumoxide`'s [one](https://github.com/sodiumoxide/sodiumoxide/blob/master/src/crypto/scalarmult/curve25519.rs#L32)), so it's not really clear what we can do in this situation.

Adding a `Result` as return type for `Dh::dh` will help with error handling.