### PR TITLE
Add libsodium resolver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ script:
   - cargo test --features "hacl-star-accelerated vector-tests" --verbose
   - cargo test --features "ring-resolver vector-tests" --verbose
   - cargo test --features "ring-accelerated vector-tests" --verbose
+  - cargo test --features "libsodium-resolver vector-tests" --verbose
+  - cargo test --features "libsodium-accelerated vector-tests" --verbose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,13 @@ rust:
   - beta
   - nightly
 cache: cargo
-
+install:
+- wget https://github.com/jedisct1/libsodium/releases/download/1.0.15/libsodium-1.0.15.tar.gz
+- tar xvfz libsodium-1.0.15.tar.gz
+- cd libsodium-1.0.15 && ./configure --prefix=$HOME/installed_libsodium && make && make install &&
+  cd ..
+- export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH
+- export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH
 script:
   - cargo test --features "hacl-star-resolver vector-tests" --verbose
   - cargo test --features "hacl-star-accelerated vector-tests" --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,15 @@ readme = "README.md"
 keywords = ["noise", "protocol", "crypto"]
 
 [features]
-default = ["default-resolver"]
+default = ["default-resolver", "libsodium-resolver"]
 nightly = ["blake2-rfc/simd_opt", "chacha20-poly1305-aead/simd_opt", "x25519-dalek/nightly"]
 default-resolver = ["chacha20-poly1305-aead", "blake2-rfc", "rust-crypto", "x25519-dalek", "rand"]
 hacl-star-resolver = ["hacl-star"]
 hacl-star-accelerated = ["hacl-star-resolver", "default-resolver"]
 ring-resolver = ["ring"]
 ring-accelerated = ["ring-resolver", "default-resolver"]
+libsodium-resolver = ["sodiumoxide"]
+libsodium-accelerated = ["libsodium-resolver", "default-resolver"]
 vector-tests = []
 
 [[bench]]
@@ -43,6 +45,8 @@ rust-crypto = { version = "^0.2", optional = true }
 hacl-star = { version = "=0.0.11", optional = true }
 rand = { version = "0.5.0-pre.2", optional = true }
 ring = { version = "0.13.0-alpha5", optional = true }
+#sodiumoxide = { version = "^0.1.0", optional = true } # We have to use concrete revision until version bump.
+sodiumoxide = { git = "https://github.com/sodiumoxide/sodiumoxide", rev = "d01bbdbd91313453ae244d56973545d9b695af20", optional = true }
 
 [dev-dependencies]
 clap = "^2.0"
@@ -57,7 +61,7 @@ lazy_static = "^1.0"
 rustc_version = "^0.2"
 
 [package.metadata.docs.rs]
-features = [ "ring-resolver", "hacl-star-resolver" ]
+features = [ "ring-resolver", "hacl-star-resolver", "libsodium-resolver" ]
 all-features = false
 no-default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["noise", "protocol", "crypto"]
 
 [features]
-default = ["default-resolver", "libsodium-resolver"]
+default = ["default-resolver"]
 nightly = ["blake2-rfc/simd_opt", "chacha20-poly1305-aead/simd_opt", "x25519-dalek/nightly"]
 default-resolver = ["chacha20-poly1305-aead", "blake2-rfc", "rust-crypto", "x25519-dalek", "rand"]
 hacl-star-resolver = ["hacl-star"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,3 +62,4 @@ pub use session::Session;
 #[cfg(feature = "default-resolver")]   pub use resolvers::default::DefaultResolver;
 #[cfg(feature = "ring-resolver")]      pub use resolvers::ring::RingResolver;
 #[cfg(feature = "hacl-star-resolver")] pub use resolvers::hacl_star::HaclStarResolver;
+#[cfg(feature = "libsodium-resolver")] pub use resolvers::libsodium::SodiumResolver;

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -59,6 +59,13 @@ impl<'builder> NoiseBuilder<'builder> {
         Self::with_resolver(params, Box::new(FallbackResolver::new(Box::new(HaclStarResolver), Box::new(DefaultResolver))))
     }
 
+    #[cfg(feature = "libsodium-accelerated")]
+    pub fn new(params: NoiseParams) -> Self {
+        use ::resolvers::{FallbackResolver, default::DefaultResolver, libsodium::SodiumResolver};
+
+        Self::with_resolver(params, Box::new(FallbackResolver::new(Box::new(SodiumResolver), Box::new(DefaultResolver))))
+    }
+
     /// Create a NoiseBuilder with a custom crypto resolver.
     pub fn with_resolver(params: NoiseParams, resolver: Box<CryptoResolver>) -> Self
     {

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -38,7 +38,7 @@ pub struct NoiseBuilder<'builder> {
 
 impl<'builder> NoiseBuilder<'builder> {
     /// Create a NoiseBuilder with the default crypto resolver.
-    #[cfg(all(feature = "default-resolver", not(any(feature = "ring-accelerated", feature = "hacl-star-accelerated"))))]
+    #[cfg(all(feature = "default-resolver", not(any(feature = "ring-accelerated", feature = "hacl-star-accelerated", feature = "libsodium-accelerated"))))]
     pub fn new(params: NoiseParams) -> Self {
         use ::resolvers::default::DefaultResolver;
 

--- a/src/resolvers/libsodium.rs
+++ b/src/resolvers/libsodium.rs
@@ -6,7 +6,7 @@ use params::{CipherChoice, DHChoice, HashChoice};
 use types::{Cipher, Dh, Hash, Random};
 use CryptoResolver;
 
-use self::sodiumoxide::crypto::aead::chacha20poly1305 as sodium_chacha20poly1305;
+use self::sodiumoxide::crypto::aead::chacha20poly1305_ietf as sodium_chacha20poly1305;
 use self::sodiumoxide::crypto::hash::sha256 as sodium_sha256;
 use self::sodiumoxide::crypto::scalarmult::curve25519 as sodium_curve25519;
 
@@ -140,8 +140,8 @@ impl Cipher for SodiumChaChaPoly {
     }
 
     fn encrypt(&self, nonce: u64, authtext: &[u8], plaintext: &[u8], out: &mut [u8]) -> usize {
-        let mut nonce_bytes = [0u8; 8];
-        LittleEndian::write_u64(&mut nonce_bytes[..], nonce);
+        let mut nonce_bytes = [0u8; 12];
+        LittleEndian::write_u64(&mut nonce_bytes[4..], nonce);
         let nonce = sodium_chacha20poly1305::Nonce(nonce_bytes);
 
         let buf = sodium_chacha20poly1305::seal(plaintext, Some(authtext), &nonce, &self.key);
@@ -157,8 +157,8 @@ impl Cipher for SodiumChaChaPoly {
         ciphertext: &[u8],
         out: &mut [u8],
     ) -> Result<usize, ()> {
-        let mut nonce_bytes = [0u8; 8];
-        LittleEndian::write_u64(&mut nonce_bytes[..], nonce);
+        let mut nonce_bytes = [0u8; 12];
+        LittleEndian::write_u64(&mut nonce_bytes[4..], nonce);
         let nonce = sodium_chacha20poly1305::Nonce(nonce_bytes);
 
         let result = sodium_chacha20poly1305::open(ciphertext, Some(authtext), &nonce, &self.key);

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -3,6 +3,7 @@
 #[cfg(feature = "default-resolver")]   pub mod default;
 #[cfg(feature = "hacl-star-resolver")] pub mod hacl_star;
 #[cfg(feature = "ring-resolver")]      pub mod ring;
+#[cfg(feature = "libsodium-resolver")] pub mod libsodium;
 
 use params::*;
 use types::*;

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -371,7 +371,7 @@ fn test_transport_message_exceeds_max_len() {
     let mut noise = NoiseBuilder::new(params).remote_public_key(&[0u8; 32]).build_initiator().unwrap();
 
     let mut buffer_out = [0u8; 65535*2];
-    noise.write_message(&[0u8; 0], &mut buffer_out).unwrap();
+    let _res = noise.write_message(&[0u8; 0], &mut buffer_out);
     noise = noise.into_transport_mode().unwrap();
     assert!(noise.write_message(&[0u8; 65534], &mut buffer_out).is_err());
 }
@@ -382,7 +382,7 @@ fn test_transport_message_undersized_output_buffer() {
     let mut noise = NoiseBuilder::new(params).remote_public_key(&[0u8; 32]).build_initiator().unwrap();
 
     let mut buffer_out = [0u8; 200];
-    noise.write_message(&[0u8; 0], &mut buffer_out).unwrap();
+    let _res = noise.write_message(&[0u8; 0], &mut buffer_out);
     noise = noise.into_transport_mode().unwrap();
     assert!(noise.write_message(&[0u8; 300], &mut buffer_out).is_err());
 }
@@ -393,7 +393,7 @@ fn test_oneway_initiator_enforcements() {
     let mut noise = NoiseBuilder::new(params).remote_public_key(&[0u8; 32]).build_initiator().unwrap();
 
     let mut buffer_out = [0u8; 1024];
-    noise.write_message(&[0u8; 0], &mut buffer_out).unwrap();
+    let _res = noise.write_message(&[0u8; 0], &mut buffer_out);
     noise = noise.into_transport_mode().unwrap();
     assert!(noise.read_message(&[0u8; 1024], &mut buffer_out).is_err());
 }


### PR DESCRIPTION
This PR adds a new resolver based on `libsodium-sys`/`sodiumoxide`. 

Unfortunately, current state of `sodiumoxide` lacks some features (e.g. `crypto_sign_ed25519_pk_to_curve25519` function), so code looks a bit raw.
Also the last release does not have `Clone` trait implemented for `State` structure in `Sha256`, so we have to use concrete revision.

However, I'm working on implementing necessary changes to `sodiumoxide` and as soon as they're added I'll update this implementation also.