### PR TITLE
Resolve rand dependency conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ chacha20-poly1305-aead = { version = "^0.1", optional = true }
 blake2-rfc = { version = "^0.2", optional = true }
 rust-crypto = { version = "^0.2", optional = true }
 hacl-star = { version = "=0.0.11", optional = true }
-rand = { version = "0.5.0-pre.2", optional = true }
+rand = { version = "0.5.4", optional = true }
 ring = { version = "^0.13.0", optional = true }
 x25519-dalek = { version = "^0.2", optional = true, default-features = false, features = ["std", "u64_backend"] }
 


### PR DESCRIPTION
Explicitly depending on `0.5.0-pre.2` seems to prevent me from bumping my snow dependency due to dependency conflicts. Since 0.5.4 was released by now it might be a good idea to use that instead.

Depends on https://github.com/dalek-cryptography/x25519-dalek/pull/11 to be released first to avoid dependency conflicts in snow itself.