### PR TITLE
add wasm-resolver which uses rust-crypto-wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["noise", "protocol", "crypto"]
 default = ["default-resolver"]
 nightly = ["blake2-rfc/simd_opt", "chacha20-poly1305-aead/simd_opt", "x25519-dalek/nightly"]
 default-resolver = ["chacha20-poly1305-aead", "blake2-rfc", "rust-crypto", "x25519-dalek", "rand"]
+wasm-resolver = ["chacha20-poly1305-aead", "blake2-rfc", "rust-crypto-wasm", "x25519-dalek", "rand"]
 hacl-star-resolver = ["hacl-star"]
 hacl-star-accelerated = ["hacl-star-resolver", "default-resolver"]
 ring-resolver = ["ring"]
@@ -40,8 +41,9 @@ static_slice = "0.0.3"
 chacha20-poly1305-aead = { version = "^0.1", optional = true }
 blake2-rfc = { version = "^0.2", optional = true }
 rust-crypto = { version = "^0.2", optional = true }
+rust-crypto-wasm = { version = "^0.3.1", optional = true }
 hacl-star = { version = "=0.0.11", optional = true }
-rand = { version = "^0.5", optional = true }
+rand = { version = "^0.5", optional = true, features = ["stdweb"] }
 ring = { version = "^0.13.0", optional = true }
 x25519-dalek = { version = "^0.3", optional = true, default-features = false, features = ["std", "u64_backend"] }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -46,7 +46,8 @@ pub struct Builder<'builder> {
 
 impl<'builder> Builder<'builder> {
     /// Create a Builder with the default crypto resolver.
-    #[cfg(all(feature = "default-resolver", not(any(feature = "ring-accelerated", feature = "hacl-star-accelerated"))))]
+    #[cfg(all(any(feature = "default-resolver", feature = "wasm-resolver"),
+    not(any(feature = "ring-accelerated", feature = "hacl-star-accelerated"))))]
     pub fn new(params: NoiseParams) -> Self {
         use ::resolvers::DefaultResolver;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(try_from))]
 
-#[cfg(any(feature = "default-resolver", feature = "hacl-star-resolver"))]
+#[cfg(any(feature = "default-resolver", feature="wasm-resolver", feature = "hacl-star-resolver"))]
 #[macro_use]
 extern crate arrayref;
 

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -3,6 +3,8 @@
 
 /// The default primitive resolver.
 #[cfg(feature = "default-resolver")]   mod default;
+/// The same with the wasm fork of crypto
+#[cfg(feature = "wasm-resolver")]      mod default;
 /// A HACL* primitive resolver.
 #[cfg(feature = "hacl-star-resolver")] mod hacl_star;
 /// A ring primitive resolver.
@@ -12,6 +14,7 @@ use params::{CipherChoice, DHChoice, HashChoice};
 use types::{Cipher, Dh, Hash, Random};
 
 #[cfg(feature = "default-resolver")]   pub use self::default::DefaultResolver;
+#[cfg(feature = "wasm-resolver")]      pub use self::default::DefaultResolver;
 #[cfg(feature = "hacl-star-resolver")] pub use self::hacl_star::HaclStarResolver;
 #[cfg(feature = "ring-resolver")]      pub use self::ring::RingResolver;
 


### PR DESCRIPTION
Fixes #33 

this enables building for wasm with

    cargo build --no-default-features --features=wasm-resolver


adding stdweb to rand appears to have no effect for non-wasm.