### PR TITLE
add noise spec compliant rekey functionality

### DIFF
--- a/src/cipherstate.rs
+++ b/src/cipherstate.rs
@@ -57,6 +57,10 @@ impl CipherState {
         self.cipher.rekey();
     }
 
+    pub fn rekey_manually(&mut self, key: &[u8]) {
+        self.cipher.set(key);
+    }
+
     pub fn nonce(&self) -> u64 {
         self.n
     }
@@ -81,9 +85,16 @@ impl CipherStates {
         self.0.rekey()
     }
 
+    pub fn rekey_initiator_manually(&mut self, key: &[u8]) {
+        self.0.rekey_manually(key)
+    }
 
     pub fn rekey_responder(&mut self) {
         self.1.rekey()
+    }
+
+    pub fn rekey_responder_manually(&mut self, key: &[u8]) {
+        self.1.rekey_manually(key)
     }
 }
 
@@ -134,6 +145,10 @@ impl StatelessCipherState {
     pub fn rekey(&mut self) {
         self.cipher.rekey()
     }
+
+    pub fn rekey_manually(&mut self, key: &[u8]) {
+        self.cipher.set(key);
+    }
 }
 
 impl From<CipherState> for StatelessCipherState {
@@ -166,8 +181,15 @@ impl StatelessCipherStates {
         self.0.rekey()
     }
 
+    pub fn rekey_initiator_manually(&mut self, key: &[u8]) {
+        self.0.rekey_manually(key)
+    }
 
     pub fn rekey_responder(&mut self) {
         self.1.rekey()
+    }
+
+    pub fn rekey_responder_manually(&mut self, key: &[u8]) {
+        self.1.rekey_manually(key)
     }
 }

--- a/src/cipherstate.rs
+++ b/src/cipherstate.rs
@@ -53,8 +53,8 @@ impl CipherState {
         self.decrypt_ad(&[0u8;0], ciphertext, out)
     }
 
-    pub fn rekey(&mut self, key: &[u8]) {
-        self.cipher.set(key);
+    pub fn rekey(&mut self) {
+        self.cipher.rekey();
     }
 
     pub fn nonce(&self) -> u64 {
@@ -77,13 +77,13 @@ impl CipherStates {
         Ok(CipherStates(initiator, responder))
     }
 
-    pub fn rekey_initiator(&mut self, key: &[u8]) {
-        self.0.rekey(key)
+    pub fn rekey_initiator(&mut self) {
+        self.0.rekey()
     }
 
 
-    pub fn rekey_responder(&mut self, key: &[u8]) {
-        self.1.rekey(key)
+    pub fn rekey_responder(&mut self) {
+        self.1.rekey()
     }
 }
 
@@ -131,8 +131,8 @@ impl StatelessCipherState {
         self.decrypt_ad(nonce, &[], ciphertext, out)
     }
 
-    pub fn rekey(&mut self, key: &[u8]) {
-        self.cipher.set(key);
+    pub fn rekey(&mut self) {
+        self.cipher.rekey()
     }
 }
 
@@ -162,12 +162,12 @@ impl StatelessCipherStates {
         Ok(StatelessCipherStates(initiator, responder))
     }
 
-    pub fn rekey_initiator(&mut self, key: &[u8]) {
-        self.0.rekey(key)
+    pub fn rekey_initiator(&mut self) {
+        self.0.rekey()
     }
 
 
-    pub fn rekey_responder(&mut self, key: &[u8]) {
-        self.1.rekey(key)
+    pub fn rekey_responder(&mut self) {
+        self.1.rekey()
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -202,6 +202,36 @@ impl Session {
         }
     }
 
+    /// Set a new key for the one or both of the initiator-egress and responder-egress symmetric ciphers.
+    ///
+    /// # Errors
+    ///
+    /// Will result in `SnowError::State` if not in transport mode.
+    #[must_use]
+    pub fn rekey_manually(&mut self, initiator: Option<&[u8]>, responder: Option<&[u8]>) -> Result<(), SnowError> {
+        match *self {
+            Session::Handshake(_) => bail!(StateProblem::HandshakeNotFinished),
+            Session::Transport(ref mut state) => {
+                if let Some(key) = initiator {
+                    state.rekey_initiator_manually(key);
+                }
+                if let Some(key) = responder {
+                    state.rekey_responder_manually(key);
+                }
+                Ok(())
+            },
+            Session::StatelessTransport(ref mut state) => {
+                if let Some(key) = initiator {
+                    state.rekey_initiator_manually(key);
+                }
+                if let Some(key) = responder {
+                    state.rekey_responder_manually(key);
+                }
+                Ok(())
+            },
+        }
+    }
+
     /// Get the forthcoming inbound nonce value.
     ///
     /// # Errors

--- a/src/session.rs
+++ b/src/session.rs
@@ -156,31 +156,47 @@ impl Session {
         }
     }
 
-    /// Set a new key for the one or both of the initiator-egress and responder-egress symmetric ciphers.
+    /// Generates a new key for the the initiator-egress symmetric cipher according to
+    /// Section 4.2 of the Noise Specification. Synchronizing timing of rekey between
+    /// initiator and responder is the responsibility of the application, as described in
+    /// Section 11.3 of the Noise Specification.
     ///
     /// # Errors
     ///
     /// Will result in `SnowError::State` if not in transport mode.
     #[must_use]
-    pub fn rekey(&mut self, initiator: Option<&[u8]>, responder: Option<&[u8]>) -> Result<(), SnowError> {
+    pub fn rekey_initiator(&mut self) -> Result<(), SnowError> {
         match *self {
             Session::Handshake(_) => bail!(StateProblem::HandshakeNotFinished),
             Session::Transport(ref mut state) => {
-                if let Some(key) = initiator {
-                    state.rekey_initiator(key);
-                }
-                if let Some(key) = responder {
-                    state.rekey_responder(key);
-                }
+                state.rekey_initiator();
                 Ok(())
             },
             Session::StatelessTransport(ref mut state) => {
-                if let Some(key) = initiator {
-                    state.rekey_initiator(key);
-                }
-                if let Some(key) = responder {
-                    state.rekey_responder(key);
-                }
+                state.rekey_initiator();
+                Ok(())
+            },
+        }
+    }
+
+    /// Generates a new key for the the responder-egress symmetric cipher according to
+    /// Section 4.2 of the Noise Specification. Synchronizing timing of rekey between
+    /// initiator and responder is the responsibility of the application, as described in
+    /// Section 11.3 of the Noise Specification.
+    ///
+    /// # Errors
+    ///
+    /// Will result in `SnowError::State` if not in transport mode.
+    #[must_use]
+    pub fn rekey_responder(&mut self) -> Result<(), SnowError> {
+        match *self {
+            Session::Handshake(_) => bail!(StateProblem::HandshakeNotFinished),
+            Session::Transport(ref mut state) => {
+                state.rekey_responder();
+                Ok(())
+            },
+            Session::StatelessTransport(ref mut state) => {
+                state.rekey_responder();
                 Ok(())
             },
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -156,47 +156,47 @@ impl Session {
         }
     }
 
-    /// Generates a new key for the the initiator-egress symmetric cipher according to
-    /// Section 4.2 of the Noise Specification. Synchronizing timing of rekey between
-    /// initiator and responder is the responsibility of the application, as described in
-    /// Section 11.3 of the Noise Specification.
+    /// Generates a new key for the egress symmetric cipher according to Section 4.2
+    /// of the Noise Specification. Synchronizing timing of rekey between initiator and
+    /// responder is the responsibility of the application, as described in Section 11.3
+    /// of the Noise Specification.
     ///
     /// # Errors
     ///
     /// Will result in `SnowError::State` if not in transport mode.
     #[must_use]
-    pub fn rekey_initiator(&mut self) -> Result<(), SnowError> {
+    pub fn rekey_outgoing(&mut self) -> Result<(), SnowError> {
         match *self {
             Session::Handshake(_) => bail!(StateProblem::HandshakeNotFinished),
             Session::Transport(ref mut state) => {
-                state.rekey_initiator();
+                state.rekey_outgoing();
                 Ok(())
             },
             Session::StatelessTransport(ref mut state) => {
-                state.rekey_initiator();
+                state.rekey_outgoing();
                 Ok(())
             },
         }
     }
 
-    /// Generates a new key for the the responder-egress symmetric cipher according to
-    /// Section 4.2 of the Noise Specification. Synchronizing timing of rekey between
-    /// initiator and responder is the responsibility of the application, as described in
-    /// Section 11.3 of the Noise Specification.
+    /// Generates a new key for the ingress symmetric cipher according to Section 4.2
+    /// of the Noise Specification. Synchronizing timing of rekey between initiator and
+    /// responder is the responsibility of the application, as described in Section 11.3
+    /// of the Noise Specification.
     ///
     /// # Errors
     ///
     /// Will result in `SnowError::State` if not in transport mode.
     #[must_use]
-    pub fn rekey_responder(&mut self) -> Result<(), SnowError> {
+    pub fn rekey_incoming(&mut self) -> Result<(), SnowError> {
         match *self {
             Session::Handshake(_) => bail!(StateProblem::HandshakeNotFinished),
             Session::Transport(ref mut state) => {
-                state.rekey_responder();
+                state.rekey_incoming();
                 Ok(())
             },
             Session::StatelessTransport(ref mut state) => {
-                state.rekey_responder();
+                state.rekey_incoming();
                 Ok(())
             },
         }

--- a/src/stateless_transportstate.rs
+++ b/src/stateless_transportstate.rs
@@ -67,12 +67,12 @@ impl StatelessTransportState {
         cipher.decrypt(nonce, payload, message).map_err(|_| SnowError::Decrypt)
     }
 
-    pub fn rekey_initiator(&mut self, key: &[u8]) {
-        self.cipherstates.rekey_initiator(key)
+    pub fn rekey_initiator(&mut self) {
+        self.cipherstates.rekey_initiator()
     }
 
-    pub fn rekey_responder(&mut self, key: &[u8]) {
-        self.cipherstates.rekey_responder(key)
+    pub fn rekey_responder(&mut self) {
+        self.cipherstates.rekey_responder()
     }
 
     pub fn is_initiator(&self) -> bool {

--- a/src/stateless_transportstate.rs
+++ b/src/stateless_transportstate.rs
@@ -71,8 +71,16 @@ impl StatelessTransportState {
         self.cipherstates.rekey_initiator()
     }
 
+    pub fn rekey_initiator_manually(&mut self, key: &[u8]) {
+        self.cipherstates.rekey_initiator_manually(key)
+    }
+
     pub fn rekey_responder(&mut self) {
         self.cipherstates.rekey_responder()
+    }
+
+    pub fn rekey_responder_manually(&mut self, key: &[u8]) {
+        self.cipherstates.rekey_responder_manually(key)
     }
 
     pub fn is_initiator(&self) -> bool {

--- a/src/stateless_transportstate.rs
+++ b/src/stateless_transportstate.rs
@@ -67,16 +67,24 @@ impl StatelessTransportState {
         cipher.decrypt(nonce, payload, message).map_err(|_| SnowError::Decrypt)
     }
 
-    pub fn rekey_initiator(&mut self) {
-        self.cipherstates.rekey_initiator()
+    pub fn rekey_outgoing(&mut self) {
+        if self.initiator {
+            self.cipherstates.rekey_initiator()
+        } else {
+            self.cipherstates.rekey_responder()
+        }
+    }
+
+    pub fn rekey_incoming(&mut self) {
+        if self.initiator {
+            self.cipherstates.rekey_responder()
+        } else {
+            self.cipherstates.rekey_initiator()
+        }
     }
 
     pub fn rekey_initiator_manually(&mut self, key: &[u8]) {
         self.cipherstates.rekey_initiator_manually(key)
-    }
-
-    pub fn rekey_responder(&mut self) {
-        self.cipherstates.rekey_responder()
     }
 
     pub fn rekey_responder_manually(&mut self, key: &[u8]) {

--- a/src/transportstate.rs
+++ b/src/transportstate.rs
@@ -69,8 +69,16 @@ impl TransportState {
         self.cipherstates.rekey_initiator()
     }
 
+    pub fn rekey_initiator_manually(&mut self, key: &[u8]) {
+        self.cipherstates.rekey_initiator_manually(key)
+    }
+
     pub fn rekey_responder(&mut self) {
         self.cipherstates.rekey_responder()
+    }
+
+    pub fn rekey_responder_manually(&mut self, key: &[u8]) {
+        self.cipherstates.rekey_responder_manually(key)
     }
 
     /// Sets the *receiving* CipherState's nonce. Useful for using noise on lossy transports.

--- a/src/transportstate.rs
+++ b/src/transportstate.rs
@@ -65,16 +65,24 @@ impl TransportState {
         cipher.decrypt(payload, message).map_err(|_| SnowError::Decrypt)
     }
 
-    pub fn rekey_initiator(&mut self) {
-        self.cipherstates.rekey_initiator()
+    pub fn rekey_outgoing(&mut self) {
+        if self.initiator {
+            self.cipherstates.rekey_initiator()
+        } else {
+            self.cipherstates.rekey_responder()
+        }
+    }
+
+    pub fn rekey_incoming(&mut self) {
+        if self.initiator {
+            self.cipherstates.rekey_responder()
+        } else {
+            self.cipherstates.rekey_initiator()
+        }
     }
 
     pub fn rekey_initiator_manually(&mut self, key: &[u8]) {
         self.cipherstates.rekey_initiator_manually(key)
-    }
-
-    pub fn rekey_responder(&mut self) {
-        self.cipherstates.rekey_responder()
     }
 
     pub fn rekey_responder_manually(&mut self, key: &[u8]) {

--- a/src/transportstate.rs
+++ b/src/transportstate.rs
@@ -65,12 +65,12 @@ impl TransportState {
         cipher.decrypt(payload, message).map_err(|_| SnowError::Decrypt)
     }
 
-    pub fn rekey_initiator(&mut self, key: &[u8]) {
-        self.cipherstates.rekey_initiator(key)
+    pub fn rekey_initiator(&mut self) {
+        self.cipherstates.rekey_initiator()
     }
 
-    pub fn rekey_responder(&mut self, key: &[u8]) {
-        self.cipherstates.rekey_responder(key)
+    pub fn rekey_responder(&mut self) {
+        self.cipherstates.rekey_responder()
     }
 
     /// Sets the *receiving* CipherState's nonce. Useful for using noise on lossy transports.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! The traits for cryptographic implementations that can be used by Noise.
 
-use constants::{MAXBLOCKLEN, MAXHASHLEN, TAGLEN};
+use constants::{CIPHERKEYLEN, MAXBLOCKLEN, MAXHASHLEN, TAGLEN};
 
 /// CSPRNG operations
 pub trait Random : Send + Sync {
@@ -54,10 +54,10 @@ pub trait Cipher : Send + Sync {
     /// Rekey according to Section 4.2 of the Noise Specification, with a default
     /// implementation guaranteed to be secure for all ciphers.
     fn rekey(&mut self) {
-        let mut ciphertext = [0; 32 + TAGLEN];
-        let ciphertext_len = self.encrypt(u64::max_value(), &[], &[0; 32], &mut ciphertext);
+        let mut ciphertext = [0; CIPHERKEYLEN + TAGLEN];
+        let ciphertext_len = self.encrypt(u64::max_value(), &[], &[0; CIPHERKEYLEN], &mut ciphertext);
         assert_eq!(ciphertext_len, ciphertext.len());
-        self.set(&ciphertext[..32]);
+        self.set(&ciphertext[..CIPHERKEYLEN]);
     }
 }
 

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -306,7 +306,10 @@ fn test_rekey() {
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
     let mut h_r = Builder::new(params).build_responder().unwrap();
 
-    assert!(h_i.rekey(None, None).is_err());
+    assert!(h_i.rekey_initiator().is_err());
+    assert!(h_i.rekey_responder().is_err());
+    assert!(h_r.rekey_initiator().is_err());
+    assert!(h_r.rekey_responder().is_err());
 
     let mut buffer_msg = [0u8; 200];
     let mut buffer_out = [0u8; 200];
@@ -319,17 +322,29 @@ fn test_rekey() {
     let mut h_i = h_i.into_transport_mode().unwrap();
     let mut h_r = h_r.into_transport_mode().unwrap();
 
+    // test message initiator->responder before rekeying initiator
     let len = h_i.write_message(b"hack the planet", &mut buffer_msg).unwrap();
     let len = h_r.read_message(&buffer_msg[..len], &mut buffer_out).unwrap();
     assert_eq!(&buffer_out[..len], b"hack the planet");
 
-    h_i.rekey(Some(&[1u8; 32]), Some(&[2u8; 32])).unwrap();
-    h_r.rekey(Some(&[1u8; 32]), Some(&[2u8; 32])).unwrap();
+    // rekey initiator (on initiator)
+    h_i.rekey_initiator().unwrap();
+    let len = h_i.write_message(b"hack the planet", &mut buffer_msg).unwrap();
+    assert!(h_r.read_message(&buffer_msg[..len], &mut buffer_out).is_err());
 
+    // rekey initiator (on responder)
+    h_r.rekey_initiator().unwrap();
     let len = h_i.write_message(b"hack the planet", &mut buffer_msg).unwrap();
     let len = h_r.read_message(&buffer_msg[..len], &mut buffer_out).unwrap();
     assert_eq!(&buffer_out[..len], b"hack the planet");
 
+    // rekey responder (on responder)
+    h_r.rekey_responder().unwrap();
+    let len = h_r.write_message(b"hack the planet", &mut buffer_msg).unwrap();
+    assert!(h_i.read_message(&buffer_msg[..len], &mut buffer_out).is_err());
+
+    // rekey responder (on initiator)
+    h_i.rekey_responder().unwrap();
     let len = h_r.write_message(b"hack the planet", &mut buffer_msg).unwrap();
     let len = h_i.read_message(&buffer_msg[..len], &mut buffer_out).unwrap();
     assert_eq!(&buffer_out[..len], b"hack the planet");

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -306,10 +306,10 @@ fn test_rekey() {
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
     let mut h_r = Builder::new(params).build_responder().unwrap();
 
-    assert!(h_i.rekey_initiator().is_err());
-    assert!(h_i.rekey_responder().is_err());
-    assert!(h_r.rekey_initiator().is_err());
-    assert!(h_r.rekey_responder().is_err());
+    assert!(h_i.rekey_incoming().is_err());
+    assert!(h_i.rekey_outgoing().is_err());
+    assert!(h_r.rekey_incoming().is_err());
+    assert!(h_r.rekey_outgoing().is_err());
 
     let mut buffer_msg = [0u8; 200];
     let mut buffer_out = [0u8; 200];
@@ -327,24 +327,24 @@ fn test_rekey() {
     let len = h_r.read_message(&buffer_msg[..len], &mut buffer_out).unwrap();
     assert_eq!(&buffer_out[..len], b"hack the planet");
 
-    // rekey initiator (on initiator)
-    h_i.rekey_initiator().unwrap();
+    // rekey outgoing on initiator
+    h_i.rekey_outgoing().unwrap();
     let len = h_i.write_message(b"hack the planet", &mut buffer_msg).unwrap();
     assert!(h_r.read_message(&buffer_msg[..len], &mut buffer_out).is_err());
 
-    // rekey initiator (on responder)
-    h_r.rekey_initiator().unwrap();
+    // rekey incoming on responder
+    h_r.rekey_incoming().unwrap();
     let len = h_i.write_message(b"hack the planet", &mut buffer_msg).unwrap();
     let len = h_r.read_message(&buffer_msg[..len], &mut buffer_out).unwrap();
     assert_eq!(&buffer_out[..len], b"hack the planet");
 
-    // rekey responder (on responder)
-    h_r.rekey_responder().unwrap();
+    // rekey outgoing on responder
+    h_r.rekey_outgoing().unwrap();
     let len = h_r.write_message(b"hack the planet", &mut buffer_msg).unwrap();
     assert!(h_i.read_message(&buffer_msg[..len], &mut buffer_out).is_err());
 
-    // rekey responder (on initiator)
-    h_i.rekey_responder().unwrap();
+    // rekey incoming on initiator
+    h_i.rekey_incoming().unwrap();
     let len = h_r.write_message(b"hack the planet", &mut buffer_msg).unwrap();
     let len = h_i.read_message(&buffer_msg[..len], &mut buffer_out).unwrap();
     assert_eq!(&buffer_out[..len], b"hack the planet");


### PR DESCRIPTION
see issue #35. i added `Cipher::rekey` with a secure default implementation, to allow writing optimized rekey implementations (that don't calculate a tag, for example) for particular ciphers if desired, as mentioned in Section 4.2 of the Noise Spec ("If this function is not specifically defined for some set of cipher functions, then it defaults to..."). i do wonder if `Session::rekey_initiator` and `Session::rekey_responder` should instead be `Session::rekey_outgoing` and `Session::rekey_incoming`. since most everyone will end up with code like this:
```rust
// rekey outgoing
if noise.is_initiator() {
    noise.rekey_initiator()?;
} else {
    noise.rekey_responder()?;
}
```