### PR TITLE
Update to x25519-dalek 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rust-crypto = { version = "^0.2", optional = true }
 hacl-star = { version = "=0.0.11", optional = true }
 rand = { version = "^0.6", optional = true }
 ring = { version = "^0.13.0", optional = true }
-x25519-dalek = { version = "^0.3", optional = true, default-features = false, features = ["std", "u64_backend"] }
+x25519-dalek = { version = "^0.4", optional = true, default-features = false, features = ["std", "u64_backend"] }
 
 [dev-dependencies]
 clap = "^2.0"

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -130,14 +130,12 @@ impl Dh for Dh25519 {
 
     fn set(&mut self, privkey: &[u8]) {
         copy_slices!(privkey, &mut self.privkey);
-        let pubkey = x25519::generate_public(&self.privkey);
-        copy_slices!(pubkey.as_bytes(), &mut self.pubkey);
+        self.pubkey = x25519::x25519(self.privkey, x25519::X25519_BASEPOINT_BYTES);
     }
 
     fn generate(&mut self, rng: &mut Random) {
         rng.fill_bytes(&mut self.privkey);
-        let pubkey = x25519::generate_public(&self.privkey);
-        copy_slices!(pubkey.as_bytes(), &mut self.pubkey);
+        self.pubkey = x25519::x25519(self.privkey, x25519::X25519_BASEPOINT_BYTES);
     }
 
     fn pubkey(&self) -> &[u8] {
@@ -149,7 +147,7 @@ impl Dh for Dh25519 {
     }
 
     fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), ()> {
-        let result = x25519::diffie_hellman(&self.privkey, array_ref![pubkey, 0, 32]);
+        let result = x25519::x25519(self.privkey, *array_ref![pubkey, 0, 32]);
         copy_slices!(&result, out);
         Ok(())
     }

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -154,7 +154,7 @@ fn test_sanity_session() {
 fn test_Npsk0_expected_value() {
     let params: NoiseParams = "Noise_Npsk0_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params)
-        .remote_public_key(x25519::generate_public(&get_inc_key(0)).as_bytes())
+        .remote_public_key(&x25519::x25519(get_inc_key(0), x25519::X25519_BASEPOINT_BYTES))
         .psk(0, &get_inc_key(1))
         .fixed_ephemeral_key_for_testing_only(&get_inc_key(32))
         .build_initiator().unwrap();
@@ -175,7 +175,7 @@ fn test_Xpsk0_expected_value() {
     let params: NoiseParams = "Noise_Xpsk0_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params)
         .local_private_key(&get_inc_key(0))
-        .remote_public_key(x25519::generate_public(&get_inc_key(32)).as_bytes())
+        .remote_public_key(&x25519::x25519(get_inc_key(32), x25519::X25519_BASEPOINT_BYTES))
         .psk(0, &get_inc_key(1))
         .fixed_ephemeral_key_for_testing_only(&get_inc_key(64))
         .build_initiator().unwrap();
@@ -196,14 +196,14 @@ fn test_XXpsk0_expected_value() {
     let params: NoiseParams = "Noise_XXpsk0_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone())
         .local_private_key(&get_inc_key(0))
-        .remote_public_key(x25519::generate_public(&get_inc_key(1)).as_bytes())
+        .remote_public_key(&x25519::x25519(get_inc_key(1), x25519::X25519_BASEPOINT_BYTES))
         .prologue(&[1u8, 2, 3])
         .psk(0, &get_inc_key(4))
         .fixed_ephemeral_key_for_testing_only(&get_inc_key(32))
         .build_initiator().unwrap();
     let mut h_r = Builder::new(params)
         .local_private_key(&get_inc_key(1))
-        .remote_public_key(x25519::generate_public(&get_inc_key(0)).as_bytes())
+        .remote_public_key(&x25519::x25519(get_inc_key(0), x25519::X25519_BASEPOINT_BYTES))
         .prologue(&[1u8, 2, 3])
         .psk(0, &get_inc_key(4))
         .fixed_ephemeral_key_for_testing_only(&get_inc_key(33))
@@ -535,15 +535,15 @@ fn test_get_remote_static() {
     let len = h_r.write_message(&[], &mut buf).unwrap();
     let _   = h_i.read_message(&buf[..len], &mut buf2).unwrap();
 
-    assert_eq!(h_i.get_remote_static().unwrap(), x25519::generate_public(&get_inc_key(1)).as_bytes());
+    assert_eq!(h_i.get_remote_static().unwrap(), &x25519::x25519(get_inc_key(1), x25519::X25519_BASEPOINT_BYTES));
     assert!(h_r.get_remote_static().is_none());
 
     // -> s, se
     let len = h_i.write_message(&[], &mut buf).unwrap();
     let _   = h_r.read_message(&buf[..len], &mut buf2).unwrap();
 
-    assert_eq!(h_i.get_remote_static().unwrap(), x25519::generate_public(&get_inc_key(1)).as_bytes());
-    assert_eq!(h_r.get_remote_static().unwrap(), x25519::generate_public(&get_inc_key(0)).as_bytes());
+    assert_eq!(h_i.get_remote_static().unwrap(), &x25519::x25519(get_inc_key(1), x25519::X25519_BASEPOINT_BYTES));
+    assert_eq!(h_r.get_remote_static().unwrap(), &x25519::x25519(get_inc_key(0), x25519::X25519_BASEPOINT_BYTES));
 }
 
 #[test]


### PR DESCRIPTION
The 0.4.0 release changes the x25519-dalek API to have two levels: a bare
byte-oriented API that matches the RFC exactly, and a higher-level ephemeral DH
API, which handles things like memory zeroing and use-once semantics for
ephemeral keys.

More importantly, it uses the stable curve25519-dalek version, so upgrading
will let us yank pre-release versions without breaking builds for snow users.

This changeset doesn't use the nicer Rust API since I'm not sure how it should
be integrated with Snow's existing DH abstractions, but the bare byte-oriented
API won't change, so Snow could upgrade to the nicer API at some point in the
future.