### PR TITLE
Fix panic! when passing short buffer to read

### DIFF
--- a/src/handshakestate.rs
+++ b/src/handshakestate.rs
@@ -272,9 +272,7 @@ impl HandshakeState {
             for token in self.message_patterns[self.pattern_position].iter() {
                 match *token {
                     Token::E => {
-                        if ptr.len() < dh_len {
-                            bail!(SnowError::Input);
-                        }
+                        if ptr.len() < dh_len { bail!(SnowError::Input); }
                         self.re[..dh_len].copy_from_slice(&ptr[..dh_len]);
                         ptr = &ptr[dh_len..];
                         self.symmetricstate.mix_hash(&self.re[..dh_len]);
@@ -285,10 +283,12 @@ impl HandshakeState {
                     },
                     Token::S => {
                         let data = if self.symmetricstate.has_key() {
+                            if ptr.len() < dh_len + TAGLEN { bail!(SnowError::Input); }
                             let temp = &ptr[..dh_len + TAGLEN];
                             ptr = &ptr[dh_len + TAGLEN..];
                             temp
                         } else {
+                            if ptr.len() < dh_len { bail!(SnowError::Input); }
                             let temp = &ptr[..dh_len];
                             ptr = &ptr[dh_len..];
                             temp

--- a/src/handshakestate.rs
+++ b/src/handshakestate.rs
@@ -272,7 +272,9 @@ impl HandshakeState {
             for token in self.message_patterns[self.pattern_position].iter() {
                 match *token {
                     Token::E => {
-                        if ptr.len() < dh_len { bail!(SnowError::Input); }
+                        if ptr.len() < dh_len {
+                            bail!(SnowError::Input);
+                        }
                         self.re[..dh_len].copy_from_slice(&ptr[..dh_len]);
                         ptr = &ptr[dh_len..];
                         self.symmetricstate.mix_hash(&self.re[..dh_len]);
@@ -283,12 +285,16 @@ impl HandshakeState {
                     },
                     Token::S => {
                         let data = if self.symmetricstate.has_key() {
-                            if ptr.len() < dh_len + TAGLEN { bail!(SnowError::Input); }
+                            if ptr.len() < dh_len + TAGLEN {
+                                bail!(SnowError::Input);
+                            }
                             let temp = &ptr[..dh_len + TAGLEN];
                             ptr = &ptr[dh_len + TAGLEN..];
                             temp
                         } else {
-                            if ptr.len() < dh_len { bail!(SnowError::Input); }
+                            if ptr.len() < dh_len {
+                                bail!(SnowError::Input);
+                            }
                             let temp = &ptr[..dh_len];
                             ptr = &ptr[dh_len..];
                             temp


### PR DESCRIPTION
I have noticed that as part of the handshake process, if a short buffer (less than 48 bytes) is passed then the library panics.

Instead, it should error out. The test reproduces the panic.