### PR TITLE
reduce Session memory footprint after handshake by heap allocating

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -28,7 +28,7 @@ use crate::stateless_transportstate::StatelessTransportState;
 #[derive(Debug)]
 pub enum Session {
     /// A session in the handshake stage (the starting state).
-    Handshake(HandshakeState),
+    Handshake(Box<HandshakeState>),
 
     /// A session after having completed a handshake, in general-purpose transport mode.
     Transport(TransportState),
@@ -336,7 +336,7 @@ impl Session {
                 if !state.is_finished() {
                     bail!(StateProblem::HandshakeNotFinished)
                 } else {
-                    Ok(Session::Transport(state.try_into()?))
+                    Ok(Session::Transport((*state).try_into()?))
                 }
             },
             _ => Ok(self)
@@ -371,7 +371,7 @@ impl Session {
                 if !state.is_finished() {
                     bail!(StateProblem::HandshakeNotFinished)
                 } else {
-                    Ok(Session::StatelessTransport(state.try_into()?))
+                    Ok(Session::StatelessTransport((*state).try_into()?))
                 }
             },
             _ => Ok(self)
@@ -381,7 +381,7 @@ impl Session {
 
 impl Into<Session> for HandshakeState {
     fn into(self) -> Session {
-        Session::Handshake(self)
+        Session::Handshake(Box::new(self))
     }
 }
 


### PR DESCRIPTION
There's a huge disparity between the sizes of HandshakeState and (Stateless)TransportState, which bloats the size of Session after handshake during transport mode. This is reflected in the TODO comment above snow::Session about the clippy warning "large_enum_variant" On my machine, HandshakeState is 1304 bytes whereas TransportState is 136 bytes.

This can most easily be mitigated by Boxing HandshakeState, which requires just one extra allocation. If we wish to avoid this allocation, maybe we should turn Session into a trait and make HandshakeState and (Stateless)TransportState public items but with private fields and methods; i.e. the only public methods would be through the Session trait. In the meantime, how does this look?