### PR TITLE
[WIP] Remove rustcrypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 [features]
 default = ["default-resolver"]
 nightly = ["blake2-rfc/simd_opt", "chacha20-poly1305-aead/simd_opt", "x25519-dalek/nightly", "subtle/nightly"]
-default-resolver = ["chacha20-poly1305-aead", "blake2-rfc", "rust-crypto", "x25519-dalek", "rand"]
+default-resolver = ["chacha20-poly1305-aead", "blake2-rfc", "sha2", "x25519-dalek", "rand"]
 hacl-star-resolver = ["hacl-star"]
 hacl-star-accelerated = ["hacl-star-resolver", "default-resolver"]
 ring-resolver = ["ring"]
@@ -38,11 +38,11 @@ arrayref = "0.3.5"
 rand_core = "0.4"
 subtle = "2.1"
 
-# default crypto provider
+# default crypto provider 
 chacha20-poly1305-aead = { version = "0.1", optional = true }
 blake2-rfc = { version = "0.2", optional = true }
+sha2 = { version = "0.8", optional = true}
 rand = { version = "0.6", optional = true }
-rust-crypto = { version = "0.2", optional = true }
 x25519-dalek = { version = "0.5", optional = true }
 
 # ring crypto proivder

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Similar to ring, if you enable the `hacl-accelerated` feature, Snow will default
 | CSPRNG     | ✔       |      |       |
 | 25519      | ✔       | ✔    | ✔     |
 | 448        |         |      |       |
-| AESGCM     | ✔       | ✔    |       |
+| AESGCM     |         | ✔    |       |
 | ChaChaPoly | ✔       | ✔    | ✔     |
 | SHA256     | ✔       | ✔    | ✔     |
 | SHA512     | ✔       | ✔    | ✔     |

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -80,32 +80,34 @@ fn benchmarks(c: &mut Criterion) {
         })
     }).throughput(Throughput::Elements(1)));
 
-    c.bench("transport", Benchmark::new("AESGCM_SHA256 throughput", |b| {
-        static PATTERN: &'static str = "Noise_NN_25519_AESGCM_SHA256";
+    if cfg!(feature = "ring-accelerated") {
+        c.bench("transport", Benchmark::new("AESGCM_SHA256 throughput", |b| {
+            static PATTERN: &'static str = "Noise_NN_25519_AESGCM_SHA256";
 
-        let mut h_i = Builder::new(PATTERN.parse().unwrap())
-            .build_initiator().unwrap();
-        let mut h_r = Builder::new(PATTERN.parse().unwrap())
-            .build_responder().unwrap();
+            let mut h_i = Builder::new(PATTERN.parse().unwrap())
+                .build_initiator().unwrap();
+            let mut h_r = Builder::new(PATTERN.parse().unwrap())
+                .build_responder().unwrap();
 
-        let mut buffer_msg = [0u8; MSG_SIZE * 2];
-        let mut buffer_out = [0u8; MSG_SIZE * 2];
+            let mut buffer_msg = [0u8; MSG_SIZE * 2];
+            let mut buffer_out = [0u8; MSG_SIZE * 2];
 
-        // get the handshaking out of the way for even testing
-        let len = h_i.write_message(&[0u8; 0], &mut buffer_msg).unwrap();
-        h_r.read_message(&buffer_msg[..len], &mut buffer_out).unwrap();
-        let len = h_r.write_message(&[0u8; 0], &mut buffer_msg).unwrap();
-        h_i.read_message(&buffer_msg[..len], &mut buffer_out).unwrap();
+            // get the handshaking out of the way for even testing
+            let len = h_i.write_message(&[0u8; 0], &mut buffer_msg).unwrap();
+            h_r.read_message(&buffer_msg[..len], &mut buffer_out).unwrap();
+            let len = h_r.write_message(&[0u8; 0], &mut buffer_msg).unwrap();
+            h_i.read_message(&buffer_msg[..len], &mut buffer_out).unwrap();
 
-        let mut h_i = h_i.into_transport_mode().unwrap();
-        let mut h_r = h_r.into_transport_mode().unwrap();
+            let mut h_i = h_i.into_transport_mode().unwrap();
+            let mut h_r = h_r.into_transport_mode().unwrap();
 
-        b.iter(move || {
-            let len = h_i.write_message(&buffer_msg[..MSG_SIZE], &mut buffer_out).unwrap();
-            let _ = h_r.read_message(&buffer_out[..len], &mut buffer_msg).unwrap();
-        })
-    }).throughput(Throughput::Bytes(MSG_SIZE as u32 * 2)));
-
+            b.iter(move || {
+                let len = h_i.write_message(&buffer_msg[..MSG_SIZE], &mut buffer_out).unwrap();
+                let _ = h_r.read_message(&buffer_out[..len], &mut buffer_msg).unwrap();
+            })
+        }).throughput(Throughput::Bytes(MSG_SIZE as u32 * 2)));
+    }
+    
     c.bench("transport", Benchmark::new("ChaChaPoly_BLAKE2s throughput", |b| {
         static PATTERN: &'static str = "Noise_NN_25519_ChaChaPoly_BLAKE2s";
 

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -1,11 +1,6 @@
-use arrayref::array_ref;
 use blake2_rfc::blake2b::Blake2b;
 use blake2_rfc::blake2s::Blake2s;
-use crypto::digest::Digest;
-use crypto::sha2::{Sha256, Sha512};
-use crypto::aes::KeySize;
-use crypto::aes_gcm::AesGcm;
-use crypto::aead::{AeadEncryptor, AeadDecryptor};
+use sha2::{Digest, Sha256, Sha512};
 use rand::rngs::OsRng;
 use x25519_dalek as x25519;
 
@@ -48,7 +43,7 @@ impl CryptoResolver for DefaultResolver {
     fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<dyn Cipher>> {
         match *choice {
             CipherChoice::ChaChaPoly => Some(Box::new(CipherChaChaPoly::default())),
-            CipherChoice::AESGCM     => Some(Box::new(CipherAESGCM::default())),
+            CipherChoice::AESGCM     => panic!("AES-GCM operation is not supported with the default resolver!"),
         }
     }
 }
@@ -60,24 +55,18 @@ struct Dh25519 {
     pubkey:  [u8; 32],
 }
 
-/// Wraps `rust-crypto`'s AES implementation.
-#[derive(Default)]
-struct CipherAESGCM {
-    key: [u8; 32],
-}
-
 /// Wraps `chacha20_poly1305_aead`'s ChaCha20Poly1305 implementation.
 #[derive(Default)]
 struct CipherChaChaPoly {
     key: [u8; 32],
 }
 
-/// Wraps `rust-crypto`'s SHA-256 implementation.
+/// Wraps `RustCrypto`'s SHA-256 implementation.
 struct HashSHA256 {
     hasher: Sha256
 }
 
-/// Wraps `rust-crypto`'s SHA-512 implementation.
+/// Wraps `RustCrypto`'s SHA-512 implementation.
 struct HashSHA512 {
     hasher: Sha512
 }
@@ -131,42 +120,6 @@ impl Dh for Dh25519 {
         let result = x25519::x25519(self.privkey, *array_ref![pubkey, 0, 32]);
         copy_slices!(&result, out);
         Ok(())
-    }
-}
-
-impl Cipher for CipherAESGCM {
-
-    fn name(&self) -> &'static str {
-        static NAME: &'static str = "AESGCM";
-        NAME
-    }
-
-    fn set(&mut self, key: &[u8]) {
-        copy_slices!(key, &mut self.key);
-    }
-
-    fn encrypt(&self, nonce: u64, authtext: &[u8], plaintext: &[u8], out: &mut[u8]) -> usize {
-        let mut nonce_bytes = [0u8; 12];
-        copy_slices!(&nonce.to_be_bytes(), &mut nonce_bytes[4..]);
-        let mut cipher = AesGcm::new(KeySize::KeySize256, &self.key, &nonce_bytes, authtext);
-        let mut tag = [0u8; TAGLEN];
-        cipher.encrypt(plaintext, &mut out[..plaintext.len()], &mut tag);
-        copy_slices!(&tag, &mut out[plaintext.len()..]);
-        plaintext.len() + TAGLEN
-    } 
-
-    fn decrypt(&self, nonce: u64, authtext: &[u8], ciphertext: &[u8], out: &mut[u8]) -> Result<usize, ()> {
-        let mut nonce_bytes = [0u8; 12];
-        copy_slices!(&nonce.to_be_bytes(), &mut nonce_bytes[4..]);
-        let mut cipher = AesGcm::new(KeySize::KeySize256, &self.key, &nonce_bytes, authtext);
-        let text_len = ciphertext.len() - TAGLEN;
-        let mut tag = [0u8; TAGLEN];
-        copy_slices!(&ciphertext[text_len..], &mut tag);
-        if cipher.decrypt(&ciphertext[..text_len], &mut out[..text_len], &tag) {
-            Ok(text_len)
-        } else {
-            Err(())
-        }
     }
 }
 
@@ -249,7 +202,8 @@ impl Hash for HashSHA256 {
     }
 
     fn result(&mut self, out: &mut [u8]) {
-        self.hasher.result(out);
+        let hash = self.hasher.clone().result();
+        out[..32].copy_from_slice(hash.as_slice())
     }
 }
 
@@ -282,7 +236,8 @@ impl Hash for HashSHA512 {
     }
 
     fn result(&mut self, out: &mut [u8]) {
-        self.hasher.result(out);
+        let hash = self.hasher.clone().result();
+        out[..64].copy_from_slice(hash.as_slice())
     }
 }
 
@@ -363,8 +318,6 @@ mod tests {
     use crate::types::*;
     use super::*;
     use self::hex::FromHex;
-    use crypto::poly1305::Poly1305;
-    use crypto::mac::Mac;
 
     #[test]
     fn test_sha256() {
@@ -429,6 +382,8 @@ mod tests {
         assert!(hex::encode(output) == "c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552");
     }
 
+    /*
+    Currently does't exist in the default resolver anymore
     #[test]
     fn test_aes256_gcm() {
     //AES256-GCM tests - gcm-spec.pdf
@@ -467,20 +422,8 @@ mod tests {
         ciphertext2[0] ^= 1;
         assert!(cipher4.decrypt(nonce, &authtext, &ciphertext2, &mut resulttext2).is_err());
     }
+    */
 
-    #[test]
-    fn test_poly1305() {
-    // Poly1305 internal test - RFC 7539
-        let key = Vec::<u8>::from_hex("85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b").unwrap();
-        let msg = Vec::<u8>::from_hex("43727970746f6772617068696320466f\
-                   72756d2052657365617263682047726f\
-                   7570").unwrap();
-        let mut poly = Poly1305::new(&key);
-        poly.input(&msg);
-        let mut output = [0u8; 16];
-        poly.raw_result(&mut output);
-        assert!(hex::encode(output) == "a8061dc1305136c6c22b8baf0c0127a9");
-    }
 
     #[test]
     fn test_chachapoly_empty() {

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -1,3 +1,4 @@
+use arrayref::array_ref;
 use blake2_rfc::blake2b::Blake2b;
 use blake2_rfc::blake2s::Blake2s;
 use sha2::{Digest, Sha256, Sha512};

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -43,7 +43,7 @@ impl CryptoResolver for DefaultResolver {
     fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<dyn Cipher>> {
         match *choice {
             CipherChoice::ChaChaPoly => Some(Box::new(CipherChaChaPoly::default())),
-            CipherChoice::AESGCM     => panic!("AES-GCM operation is not supported with the default resolver!"),
+            CipherChoice::AESGCM     => None,
         }
     }
 }
@@ -203,7 +203,7 @@ impl Hash for HashSHA256 {
 
     fn result(&mut self, out: &mut [u8]) {
         let hash = self.hasher.clone().result();
-        out[..32].copy_from_slice(hash.as_slice())
+        copy_slices!(hash.as_slice(), &mut out[..Sha256::output_size()])
     }
 }
 
@@ -237,7 +237,7 @@ impl Hash for HashSHA512 {
 
     fn result(&mut self, out: &mut [u8]) {
         let hash = self.hasher.clone().result();
-        out[..64].copy_from_slice(hash.as_slice())
+        copy_slices!(hash.as_slice(), &mut out[..Sha512::output_size()])
     }
 }
 
@@ -381,49 +381,6 @@ mod tests {
         keypair.dh(&public, &mut output).unwrap();
         assert!(hex::encode(output) == "c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552");
     }
-
-    /*
-    Currently does't exist in the default resolver anymore
-    #[test]
-    fn test_aes256_gcm() {
-    //AES256-GCM tests - gcm-spec.pdf
-        // Test Case 13
-        let key = [0u8; 32];
-        let nonce = 0u64;
-        let plaintext = [0u8; 0];
-        let authtext = [0u8; 0];
-        let mut ciphertext = [0u8; 16];
-        let mut cipher1: CipherAESGCM = Default::default();
-        cipher1.set(&key);
-        cipher1.encrypt(nonce, &authtext, &plaintext, &mut ciphertext);
-        assert!(hex::encode(ciphertext) == "530f8afbc74536b9a963b4f1c4cb738b");
-
-        let mut resulttext = [0u8; 1];
-        let mut cipher2: CipherAESGCM = Default::default();
-        cipher2.set(&key);
-        cipher2.decrypt(nonce, &authtext, &ciphertext, &mut resulttext).unwrap();
-        assert!(resulttext[0] == 0);
-        ciphertext[0] ^= 1;
-        assert!(cipher2.decrypt(nonce, &authtext, &ciphertext, &mut resulttext).is_err());
-
-        // Test Case 14
-        let plaintext2 = [0u8; 16];
-        let mut ciphertext2 = [0u8; 32];
-        let mut cipher3: CipherAESGCM = Default::default();
-        cipher3.set(&key);
-        cipher3.encrypt(nonce, &authtext, &plaintext2, &mut ciphertext2);
-        assert!(hex::encode(ciphertext2) == "cea7403d4d606b6e074ec5d3baf39d18d0d1c8a799996bf0265b98b5d48ab919");
-
-        let mut resulttext2 = [1u8; 16];
-        let mut cipher4: CipherAESGCM = Default::default();
-        cipher4.set(&key);
-        cipher4.decrypt(nonce, &authtext, &ciphertext2, &mut resulttext2).unwrap();
-        assert!(plaintext2 == resulttext2);
-        ciphertext2[0] ^= 1;
-        assert!(cipher4.decrypt(nonce, &authtext, &ciphertext2, &mut resulttext2).is_err());
-    }
-    */
-
 
     #[test]
     fn test_chachapoly_empty() {

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -130,9 +130,8 @@ fn test_noise_state_change() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_sanity_session() {
-    let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_NN_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
     let mut h_r = Builder::new(params).build_responder().unwrap();
 
@@ -153,9 +152,8 @@ fn test_sanity_session() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_Npsk0_expected_value() {
-    let params: NoiseParams = "Noise_Npsk0_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_Npsk0_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params)
         .remote_public_key(&x25519::x25519(get_inc_key(0), x25519::X25519_BASEPOINT_BYTES))
         .psk(0, &get_inc_key(1))
@@ -166,7 +164,7 @@ fn test_Npsk0_expected_value() {
     let len = h_i.write_message(&[], &mut buf).unwrap();
     assert_eq!(len, 48);
 
-    let expected = Vec::<u8>::from_hex("358072d6365880d1aeea329adf9121383851ed21a28e3b75e965d0d2cd1662542044ae563929068930dcf04674526cb9").unwrap();
+    let expected = Vec::<u8>::from_hex("358072d6365880d1aeea329adf9121383851ed21a28e3b75e965d0d2cd166254deb8a4f6190117dea09aad7546a4658c").unwrap();
 
     println!("{:?}", &expected[..]);
     println!("----------------------------------------------------------");
@@ -199,9 +197,8 @@ fn test_Xpsk0_expected_value() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_XXpsk0_expected_value() {
-    let params: NoiseParams = "Noise_XXpsk0_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_XXpsk0_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone())
         .local_private_key(&get_inc_key(0))
         .remote_public_key(&x25519::x25519(get_inc_key(1), x25519::X25519_BASEPOINT_BYTES))
@@ -235,16 +232,15 @@ fn test_XXpsk0_expected_value() {
     let len = h_r.read_message(&buf[..len], &mut buf2).unwrap();
     assert_eq!(len, 0);
 
-    let expected = Vec::<u8>::from_hex("1b6d7cc3b13bd02217f9cdb98c50870db96281193dca4df570bf6230a603b686fd90d2914c7e797d9276ef8fb34b0c9d87faa048ce4bc7e7af21b6a450352275").unwrap();
+    let expected = Vec::<u8>::from_hex("072b7bbd237ac602c4aa938db36998f31ca4750752d1758d59850c627d0bdbc51205592c3baa101b4a31f062695b7c1dbee99d5123fbd2ad03052078c570e028").unwrap();
     println!("\nreality:  {}", hex::encode(&buf[..64]));
     println!("expected: {}", hex::encode(&expected));
     assert_eq!(&buf[..64], &expected[..]);
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_NNpsk0_sanity_session() {
-    let params: NoiseParams = "Noise_NNpsk0_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_NNpsk0_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone())
         .psk(0, &[32u8; 32])
         .build_initiator()
@@ -271,9 +267,8 @@ fn test_NNpsk0_sanity_session() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_XXpsk3_sanity_session() {
-    let params: NoiseParams = "Noise_XXpsk3_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_XXpsk3_25519_ChaChaPoly_SHA256".parse().unwrap();
     let b_i = Builder::new(params.clone());
     let b_r = Builder::new(params);
     let static_i = b_i.generate_keypair().unwrap();
@@ -311,9 +306,8 @@ fn test_XXpsk3_sanity_session() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_rekey() {
-    let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_NN_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
     let mut h_r = Builder::new(params).build_responder().unwrap();
 
@@ -357,9 +351,8 @@ fn test_rekey() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_rekey_manually() {
-    let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_NN_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
     let mut h_r = Builder::new(params).build_responder().unwrap();
 
@@ -403,9 +396,8 @@ fn test_rekey_manually() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_handshake_message_exceeds_max_len() {
-    let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_NN_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params).build_initiator().unwrap();
 
     let mut buffer_out = [0u8; 65535*2];
@@ -413,9 +405,8 @@ fn test_handshake_message_exceeds_max_len() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_handshake_message_undersized_output_buffer() {
-    let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_NN_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params).build_initiator().unwrap();
 
     let mut buffer_out = [0u8; 200];
@@ -423,9 +414,8 @@ fn test_handshake_message_undersized_output_buffer() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_transport_message_exceeds_max_len() {
-    let params: NoiseParams = "Noise_N_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_N_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut noise = Builder::new(params).remote_public_key(&[0u8; 32]).build_initiator().unwrap();
 
     let mut buffer_out = [0u8; 65535*2];
@@ -435,9 +425,8 @@ fn test_transport_message_exceeds_max_len() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_transport_message_undersized_output_buffer() {
-    let params: NoiseParams = "Noise_N_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_N_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut noise = Builder::new(params).remote_public_key(&[0u8; 32]).build_initiator().unwrap();
 
     let mut buffer_out = [0u8; 200];
@@ -447,9 +436,8 @@ fn test_transport_message_undersized_output_buffer() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_oneway_initiator_enforcements() {
-    let params: NoiseParams = "Noise_N_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_N_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut noise = Builder::new(params).remote_public_key(&[0u8; 32]).build_initiator().unwrap();
 
     let mut buffer_out = [0u8; 1024];
@@ -459,9 +447,8 @@ fn test_oneway_initiator_enforcements() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_oneway_responder_enforcements() {
-    let params: NoiseParams = "Noise_N_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_N_25519_ChaChaPoly_SHA256".parse().unwrap();
     let resp_builder = Builder::new(params.clone());
     let rpk = resp_builder.generate_keypair().unwrap();
 
@@ -480,9 +467,8 @@ fn test_oneway_responder_enforcements() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_buffer_issues() {
-    let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_NN_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
     let mut h_r = Builder::new(params).build_responder().unwrap();
 
@@ -532,9 +518,8 @@ fn test_read_buffer_issues() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_buffer_issues_encrypted_handshake() {
-    let params: NoiseParams = "Noise_IKpsk2_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_IKpsk2_25519_ChaChaPoly_SHA256".parse().unwrap();
 
     let b_i = Builder::new(params.clone());
     let b_r = Builder::new(params);
@@ -579,9 +564,8 @@ fn test_send_trait() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_checkpointing() {
-    let params: NoiseParams = "Noise_XXpsk2_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_XXpsk2_25519_ChaChaPoly_SHA256".parse().unwrap();
 
     let b_i = Builder::new(params.clone());
     let b_r = Builder::new(params);
@@ -621,9 +605,8 @@ fn test_checkpointing() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_get_remote_static() {
-    let params: NoiseParams = "Noise_XX_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_XX_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone())
         .local_private_key(&get_inc_key(0))
         .build_initiator().unwrap();
@@ -661,9 +644,8 @@ fn test_get_remote_static() {
 }
 
 #[test]
-#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_set_psk() {
-    let params: NoiseParams = "Noise_XXpsk3_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_XXpsk3_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone())
         .local_private_key(&get_inc_key(0))
         .build_initiator().unwrap();
@@ -695,7 +677,7 @@ fn test_set_psk() {
 
 #[test]
 fn test_stateless_sanity_session() {
-    let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_NN_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
     let mut h_r = Builder::new(params).build_responder().unwrap();
 

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -14,7 +14,7 @@ use snow::types::*;
 use x25519_dalek as x25519;
 use rand_core::{CryptoRng, RngCore, impls};
  
- #[derive(Default)]
+#[derive(Default)]
 struct CountingRng(u64);
  
 impl RngCore for CountingRng {
@@ -130,6 +130,7 @@ fn test_noise_state_change() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_sanity_session() {
     let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
@@ -152,6 +153,7 @@ fn test_sanity_session() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_Npsk0_expected_value() {
     let params: NoiseParams = "Noise_Npsk0_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params)
@@ -165,6 +167,10 @@ fn test_Npsk0_expected_value() {
     assert_eq!(len, 48);
 
     let expected = Vec::<u8>::from_hex("358072d6365880d1aeea329adf9121383851ed21a28e3b75e965d0d2cd1662542044ae563929068930dcf04674526cb9").unwrap();
+
+    println!("{:?}", &expected[..]);
+    println!("----------------------------------------------------------");
+    println!("{:?}", &buf[..len]);
 
     println!("\nreality:  {}", hex::encode(&buf[..len]));
     println!("expected: {}", hex::encode(&expected));
@@ -193,6 +199,7 @@ fn test_Xpsk0_expected_value() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_XXpsk0_expected_value() {
     let params: NoiseParams = "Noise_XXpsk0_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone())
@@ -235,6 +242,7 @@ fn test_XXpsk0_expected_value() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_NNpsk0_sanity_session() {
     let params: NoiseParams = "Noise_NNpsk0_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone())
@@ -263,6 +271,7 @@ fn test_NNpsk0_sanity_session() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_XXpsk3_sanity_session() {
     let params: NoiseParams = "Noise_XXpsk3_25519_AESGCM_SHA256".parse().unwrap();
     let b_i = Builder::new(params.clone());
@@ -302,6 +311,7 @@ fn test_XXpsk3_sanity_session() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_rekey() {
     let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
@@ -347,6 +357,7 @@ fn test_rekey() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_rekey_manually() {
     let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
@@ -392,6 +403,7 @@ fn test_rekey_manually() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_handshake_message_exceeds_max_len() {
     let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params).build_initiator().unwrap();
@@ -401,6 +413,7 @@ fn test_handshake_message_exceeds_max_len() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_handshake_message_undersized_output_buffer() {
     let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params).build_initiator().unwrap();
@@ -410,6 +423,7 @@ fn test_handshake_message_undersized_output_buffer() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_transport_message_exceeds_max_len() {
     let params: NoiseParams = "Noise_N_25519_AESGCM_SHA256".parse().unwrap();
     let mut noise = Builder::new(params).remote_public_key(&[0u8; 32]).build_initiator().unwrap();
@@ -421,6 +435,7 @@ fn test_transport_message_exceeds_max_len() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_transport_message_undersized_output_buffer() {
     let params: NoiseParams = "Noise_N_25519_AESGCM_SHA256".parse().unwrap();
     let mut noise = Builder::new(params).remote_public_key(&[0u8; 32]).build_initiator().unwrap();
@@ -432,6 +447,7 @@ fn test_transport_message_undersized_output_buffer() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_oneway_initiator_enforcements() {
     let params: NoiseParams = "Noise_N_25519_AESGCM_SHA256".parse().unwrap();
     let mut noise = Builder::new(params).remote_public_key(&[0u8; 32]).build_initiator().unwrap();
@@ -443,6 +459,7 @@ fn test_oneway_initiator_enforcements() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_oneway_responder_enforcements() {
     let params: NoiseParams = "Noise_N_25519_AESGCM_SHA256".parse().unwrap();
     let resp_builder = Builder::new(params.clone());
@@ -463,6 +480,7 @@ fn test_oneway_responder_enforcements() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_buffer_issues() {
     let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
@@ -514,6 +532,7 @@ fn test_read_buffer_issues() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_buffer_issues_encrypted_handshake() {
     let params: NoiseParams = "Noise_IKpsk2_25519_AESGCM_SHA256".parse().unwrap();
 
@@ -560,6 +579,7 @@ fn test_send_trait() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_checkpointing() {
     let params: NoiseParams = "Noise_XXpsk2_25519_AESGCM_SHA256".parse().unwrap();
 
@@ -601,6 +621,7 @@ fn test_checkpointing() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_get_remote_static() {
     let params: NoiseParams = "Noise_XX_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone())
@@ -640,6 +661,7 @@ fn test_get_remote_static() {
 }
 
 #[test]
+#[cfg_attr(all(feature = "default-resolver", not(feature = "ring-accelerated")), should_panic)]
 fn test_set_psk() {
     let params: NoiseParams = "Noise_XXpsk3_25519_AESGCM_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone())

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -1,5 +1,5 @@
 #![cfg(any(feature = "default-resolver", feature = "ring-accelerated", feature = "hacl-star-accelerated"))]
-#![cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
+#![allow(clippy::needless_range_loop)]
 #![allow(non_snake_case)]
 use hex;
 use snow;
@@ -111,7 +111,7 @@ fn test_protocol_name() {
 
 #[test]
 fn test_noise_state_change() {
-    let params: NoiseParams = "Noise_NN_25519_AESGCM_SHA256".parse().unwrap();
+    let params: NoiseParams = "Noise_NN_25519_ChaChaPoly_SHA256".parse().unwrap();
     let mut h_i = Builder::new(params.clone()).build_initiator().unwrap();
     let mut h_r = Builder::new(params).build_responder().unwrap();
 

--- a/tests/vectors.rs
+++ b/tests/vectors.rs
@@ -251,6 +251,14 @@ fn test_vectors_from_json(json: &str) {
 
     for vector in test_vectors.vectors {
         let params: NoiseParams = vector.protocol_name.parse().unwrap();
+
+        if !cfg!(feature = "ring-accelerated") || !cfg!(feature = "ring-resolver") {
+            if params.cipher == CipherChoice::AESGCM {
+                ignored += 1;
+                continue
+            }
+        }
+
         if params.dh == DHChoice::Ed448 {
             ignored += 1;
             continue;


### PR DESCRIPTION
This PR does exactly as the name says, removes all dependence on `rust-crypto` in the default resolver.
The [sha2](https://crates.io/crates/sha2) from `RustCrypto` was chosen as the most suitable replacement.