### PR TITLE
Bump ring to version 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ sha2 = { version = "0.8", optional = true }
 x25519-dalek = { version = "0.5", optional = true }
 
 # ring crypto proivder
-ring = { version = "0.15", optional = true }
+ring = { version = "^0.16.2", optional = true, features = ["std"] }
 
 [dev-dependencies]
 clap = "2"


### PR DESCRIPTION
Currently, running `cargo build` on a clean clone of the repo is broken.

That is, because `ring` v0.15 is currently unsupported (and yanked, by the crate's policy on keeping outdated versions around).

This PR bumps `ring` to version 0.16. No breaking changes were introduced, so updating to version 0.16 should be safe.