### PR TITLE
Bump criterion to version 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ ring = { version = "0.15", optional = true }
 
 [dev-dependencies]
 clap = "2"
-criterion = "0.2"
+criterion = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -98,7 +98,7 @@ fn benchmarks(c: &mut Criterion) {
                 let len = h_i.write_message(&buffer_msg[..MSG_SIZE], &mut buffer_out).unwrap();
                 let _ = h_r.read_message(&buffer_out[..len], &mut buffer_msg).unwrap();
             })
-        }).throughput(Throughput::Bytes(MSG_SIZE as u32 * 2)));
+        }).throughput(Throughput::Bytes(MSG_SIZE as u64 * 2)));
     }
     
     c.bench("transport", Benchmark::new("ChaChaPoly_BLAKE2s throughput", |b| {
@@ -125,7 +125,7 @@ fn benchmarks(c: &mut Criterion) {
             let len = h_i.write_message(&buffer_msg[..MSG_SIZE], &mut buffer_out).unwrap();
             let _ = h_r.read_message(&buffer_out[..len], &mut buffer_msg).unwrap();
         })
-    }).throughput(Throughput::Bytes(MSG_SIZE as u32 * 2)));
+    }).throughput(Throughput::Bytes(MSG_SIZE as u64 * 2)));
 }
 
 criterion_group!(benches, benchmarks);


### PR DESCRIPTION
This PR basically bumps the version of the `criterion` crate in `Cargo.toml` to version 0.3.