### PR TITLE
add std feature for no_std compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Jake McGinty <me@jake.su>", "trevp"]
 license = "Unlicense"
 categories = ["cryptography"]
 readme = "README.md"
-keywords = ["noise", "protocol", "crypto"]
+keywords = ["noise", "protocol", "crypto", "no-std"]
 edition = "2018"
 
 # This is slightly mumbo-jumboey, but in short:
@@ -18,10 +18,11 @@ edition = "2018"
 [features]
 default = ["default-resolver"]
 nightly = ["blake2-rfc/simd_opt", "chacha20-poly1305-aead/simd_opt", "x25519-dalek/nightly", "subtle/nightly"]
-default-resolver = ["chacha20-poly1305-aead", "blake2-rfc", "sha2", "x25519-dalek", "rand"]
+default-resolver = ["chacha20-poly1305-aead", "blake2-rfc", "sha2", "x25519-dalek", "rand", "std"]
 ring-resolver = ["ring"]
 ring-accelerated = ["ring-resolver", "default-resolver"]
-vector-tests = []
+std = []
+vector-tests = ["rand/std"]
 
 [[bench]]
 name = "benches"
@@ -34,17 +35,17 @@ appveyor = { repository = "mcginty/snow", branch = "master", service = "github" 
 [dependencies]
 arrayref = "0.3.5"
 rand_core = "0.5"
-subtle = "2.1"
+subtle = { version = "2.1", default-features = false }
 
 # default crypto provider
 chacha20-poly1305-aead = { version = "0.1", optional = true }
-blake2-rfc = { version = "0.2", optional = true }
-rand = { version = "0.7", optional = true }
-sha2 = { version = "0.8", optional = true }
-x25519-dalek = { version = "0.5", optional = true }
+blake2-rfc = { version = "0.2", optional = true, default-features = false }
+rand = { version = "0.7", optional = true, default-features = false, features = ["getrandom"] }
+sha2 = { version = "0.8", optional = true, default-features = false }
+x25519-dalek = { version = "0.5", optional = true, default-features = false, features = ["u64_backend"] }
 
 # ring crypto proivder
-ring = { version = "^0.16.2", optional = true, features = ["std"] }
+ring = { version = "^0.16.2", optional = true, features = ["alloc"] }
 
 [dev-dependencies]
 clap = "2"
@@ -59,7 +60,7 @@ lazy_static = "1.3"
 rustc_version = "0.2"
 
 [package.metadata.docs.rs]
-features = [ "ring-resolver" ]
+features = [ "ring-resolver", "std" ]
 all-features = false
 no-default-features = false
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,6 +5,9 @@ use crate::utils::Toggle;
 use crate::params::NoiseParams;
 use crate::resolvers::CryptoResolver;
 use crate::error::{Error, InitStage, Prerequisite};
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::boxed::Box;
 use subtle::ConstantTimeEq;
 
 /// A keypair object returned by [`Builder::generate_keypair()`]
@@ -232,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_builder_bad_spec() {
-        let params: ::std::result::Result<NoiseParams, _> = "Noise_NK_25519_ChaChaPoly_BLAH256".parse();
+        let params: ::core::result::Result<NoiseParams, _> = "Noise_NK_25519_ChaChaPoly_BLAH256".parse();
 
         if let Ok(_) = params {
             panic!("NoiseParams should have failed");

--- a/src/cipherstate.rs
+++ b/src/cipherstate.rs
@@ -1,6 +1,7 @@
 use crate::constants::TAGLEN;
 use crate::error::{Error, InitStage, StateProblem};
 use crate::types::Cipher;
+use alloc::boxed::Box;
 
 pub(crate) struct CipherState {
     cipher : Box<dyn Cipher>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! All error types used by Snow operations.
 
-use std::fmt;
+use core::fmt;
 
 /// All errors in snow will include an `ErrorKind`.
 #[allow(missing_docs)]
@@ -126,4 +126,5 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}

--- a/src/handshakestate.rs
+++ b/src/handshakestate.rs
@@ -7,7 +7,8 @@ use crate::params::{HandshakeTokens, MessagePatterns, NoiseParams, Token};
 use crate::transportstate::TransportState;
 use crate::stateless_transportstate::StatelessTransportState;
 use crate::error::{Error, InitStage, StateProblem};
-use std::{convert::{TryFrom, TryInto}, fmt};
+use alloc::boxed::Box;
+use core::{convert::{TryFrom, TryInto}, fmt};
 
 /// A state machine encompassing the handshake phase of a Noise session.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,15 @@
 
 #![warn(missing_docs)]
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std as alloc;
+#[cfg(feature = "std")]
+extern crate core;
+
 macro_rules! copy_slices {
     ($inslice:expr, $outslice:expr) => {
         $outslice[..$inslice.len()].copy_from_slice(&$inslice[..])

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -2,7 +2,9 @@
 //! patterns/names)
 
 use crate::error::{Error, PatternProblem};
-use std::str::FromStr;
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use core::str::FromStr;
 mod patterns;
 
 pub use self::patterns::{
@@ -154,7 +156,7 @@ impl FromStr for NoiseParams {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
     use super::*;
 
     #[test]

--- a/src/params/patterns.rs
+++ b/src/params/patterns.rs
@@ -1,5 +1,7 @@
 use crate::error::{Error, PatternProblem};
-use std::{convert::TryFrom, str::FromStr};
+use alloc::vec;
+use alloc::vec::{Vec};
+use core::{convert::TryFrom, str::FromStr};
 
 /// A small helper macro that behaves similar to the `vec![]` standard macro,
 /// except it allocates a bit extra to avoid resizing.

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -8,6 +8,7 @@
 
 use crate::params::{CipherChoice, DHChoice, HashChoice};
 use crate::types::{Cipher, Dh, Hash, Random};
+use alloc::boxed::Box;
 
 #[cfg(feature = "default-resolver")]   pub use self::default::DefaultResolver;
 #[cfg(feature = "ring-resolver")]      pub use self::ring::RingResolver;

--- a/src/stateless_transportstate.rs
+++ b/src/stateless_transportstate.rs
@@ -4,7 +4,7 @@ use crate::cipherstate::StatelessCipherStates;
 use crate::constants::{MAXDHLEN, MAXMSGLEN, TAGLEN};
 use crate::handshakestate::HandshakeState;
 use crate::utils::Toggle;
-use std::{convert::TryFrom, fmt};
+use core::{convert::TryFrom, fmt};
 
 /// A state machine encompassing the transport phase of a Noise session, using the two
 /// `CipherState`s (for sending and receiving) that were spawned from the `SymmetricState`'s

--- a/src/symmetricstate.rs
+++ b/src/symmetricstate.rs
@@ -2,6 +2,7 @@ use crate::error::Error;
 use crate::constants::{CIPHERKEYLEN, MAXHASHLEN};
 use crate::types::Hash;
 use crate::cipherstate::CipherState;
+use alloc::boxed::Box;
 
 #[derive(Copy, Clone)]
 pub(crate) struct SymmetricStateData {

--- a/src/transportstate.rs
+++ b/src/transportstate.rs
@@ -4,7 +4,7 @@ use crate::cipherstate::CipherStates;
 use crate::constants::{MAXDHLEN, MAXMSGLEN, TAGLEN};
 use crate::utils::Toggle;
 use crate::handshakestate::HandshakeState;
-use std::{convert::TryFrom, fmt};
+use core::{convert::TryFrom, fmt};
 
 /// A state machine encompassing the transport phase of a Noise session, using the two
 /// `CipherState`s (for sending and receiving) that were spawned from the `SymmetricState`'s

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 /// Toggle is similar to Option, except that even in the Off/"None" case, there is still
 /// an owned allocated inner object. This is useful for holding onto pre-allocated objects


### PR DESCRIPTION
we do `extern crate std as alloc` when `std` feature is enabled, so we can still compile with rustc < 1.36.0 (when the `alloc` crate was stabilized)