### PR TITLE
Relax rand and rand_core version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,13 @@ appveyor = { repository = "mcginty/snow", branch = "master", service = "github" 
 
 [dependencies]
 arrayref = "0.3.5"
-rand_core = "0.5"
+rand_core = "^0.5"
 subtle = "2.1"
 
 # default crypto provider
 chacha20-poly1305-aead = { version = "0.1", optional = true }
 blake2-rfc = { version = "0.2", optional = true }
-rand = { version = "0.7", optional = true }
+rand = { version = "^0.7", optional = true }
 sha2 = { version = "0.8", optional = true }
 x25519-dalek = { version = "0.5", optional = true }
 


### PR DESCRIPTION
This small PR relaxes slightly the version specification for the `rand` and `rand_core` dependencies to fix conflicts that `cargo` was struggling with, particularly when trying to compile [rust-libp2p](https://github.com/libp2p/rust-libp2p/)'s noise crate.

The crate still compiles and all tests pass.