### PR TITLE
Fix FallbackResolver for HFS

### DIFF
--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -64,4 +64,9 @@ impl CryptoResolver for FallbackResolver {
     fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<dyn Cipher>> {
         self.preferred.resolve_cipher(choice).or_else(|| self.fallback.resolve_cipher(choice))
     }
+
+    #[cfg(feature = "hfs")]
+    fn resolve_kem(&self, choice: &KemChoice) -> Option<Box<dyn Kem>> {
+        self.preferred.resolve_kem(choice).or_else(|| self.fallback.resolve_kem(choice))
+    }
 }


### PR DESCRIPTION
Adding [new method](https://github.com/mcginty/snow/blob/ffbcb0a7e210a85f98e8cd3ed863726d6faf2eca/src/resolvers/mod.rs#L33) to CryptoResolver have not introduced any changes in [FallbackResolver](https://docs.rs/snow/0.6.2/snow/resolvers/struct.FallbackResolver.html), so `FallbackResolver::resolve_kem()` always returns `None` which's an obvious bug.