### PR TITLE
Made builder Send

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,7 +4,7 @@ use crate::cipherstate::{CipherState, CipherStates};
 use crate::utils::Toggle;
 use crate::params::NoiseParams;
 #[cfg(feature = "hfs")] use crate::params::HandshakeModifier;
-use crate::resolvers::CryptoResolver;
+use crate::resolvers::{CryptoResolver, BoxedCryptoResolver};
 use crate::error::{Error, InitStage, Prerequisite};
 use subtle::ConstantTimeEq;
 
@@ -47,7 +47,7 @@ impl PartialEq for Keypair {
 /// ```
 pub struct Builder<'builder> {
     params:   NoiseParams,
-    resolver: Box<dyn CryptoResolver>,
+    resolver: BoxedCryptoResolver,
     s:        Option<&'builder [u8]>,
     e_fixed:  Option<&'builder [u8]>,
     rs:       Option<&'builder [u8]>,
@@ -73,7 +73,7 @@ impl<'builder> Builder<'builder> {
     }
 
     /// Create a Builder with a custom crypto resolver.
-    pub fn with_resolver(params: NoiseParams, resolver: Box<dyn CryptoResolver>) -> Self {
+    pub fn with_resolver(params: NoiseParams, resolver: BoxedCryptoResolver) -> Self {
         Builder {
             params,
             resolver,

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -14,6 +14,9 @@ use crate::types::{Cipher, Dh, Hash, Random};
 #[cfg(feature = "default-resolver")]   pub use self::default::DefaultResolver;
 #[cfg(feature = "ring-resolver")]      pub use self::ring::RingResolver;
 
+/// Boxed CryptoResolver
+pub type BoxedCryptoResolver = Box<dyn CryptoResolver + Send>;
+
 /// An object that resolves the providers of Noise crypto choices
 pub trait CryptoResolver {
     /// Provide an implementation of the Random trait or None if none available.
@@ -37,13 +40,13 @@ pub trait CryptoResolver {
 /// can fallback to another if the first didn't have an implementation for
 /// a given primitive.
 pub struct FallbackResolver {
-    preferred: Box<dyn CryptoResolver>,
-    fallback: Box<dyn CryptoResolver>,
+    preferred: BoxedCryptoResolver,
+    fallback: BoxedCryptoResolver,
 }
 
 impl FallbackResolver {
     /// Create a new `FallbackResolver` that holds the primary and secondary resolver.
-    pub fn new(preferred: Box<dyn CryptoResolver>, fallback: Box<dyn CryptoResolver>) -> Self {
+    pub fn new(preferred: BoxedCryptoResolver, fallback: BoxedCryptoResolver) -> Self {
         Self { preferred, fallback }
     }
 }


### PR DESCRIPTION
Tiny PR to make builder `Send`.  `Box<dyn CryptoResolver>` cannot be sent between threads safely. Client code could work around this by ensuring that the builder with a custom resolver does not get included in a future's (async block's) state, however it may be considered more ergonomic to add the Send trait bound.