### PR TITLE
Add XChaChaPoly cipher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ libsodium-accelerated = ["libsodium-resolver", "default-resolver"]
 vector-tests = []
 hfs = []
 pqclean_kyber1024 = ["pqcrypto-kyber", "pqcrypto-traits", "hfs", "default-resolver"]
+xchachapoly = ["chacha20poly1305", "default-resolver"]
 risky-raw-split = []
 
 [[bench]]

--- a/ci-tests.sh
+++ b/ci-tests.sh
@@ -2,13 +2,15 @@
 set -e
 TARGET="$([ -n "$1" ] && echo "--target $1" || echo "")"
 
+COMMON_FEATURES="xchachapoly vector-tests"
+
 set -x
 cargo check --benches
 cargo test $TARGET --no-default-features
-cargo test $TARGET --features "vector-tests"
-cargo test $TARGET --features "ring-resolver vector-tests"
-cargo test $TARGET --features "ring-accelerated vector-tests"
-cargo test $TARGET --features "hfs pqclean_kyber1024 vector-tests"
-cargo test $TARGET --features "ring-resolver hfs pqclean_kyber1024 vector-tests"
-cargo test $TARGET --features "libsodium-resolver vector-tests"
-cargo test $TARGET --features "libsodium-accelerated vector-tests"
+cargo test $TARGET --features "$COMMON_FEATURES"
+cargo test $TARGET --features "ring-resolver $COMMON_FEATURES"
+cargo test $TARGET --features "ring-accelerated $COMMON_FEATURES"
+cargo test $TARGET --features "hfs pqclean_kyber1024 $COMMON_FEATURES"
+cargo test $TARGET --features "ring-resolver hfs pqclean_kyber1024 $COMMON_FEATURES"
+cargo test $TARGET --features "libsodium-resolver $COMMON_FEATURES"
+cargo test $TARGET --features "libsodium-accelerated $COMMON_FEATURES"

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -56,6 +56,8 @@ impl FromStr for DHChoice {
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub enum CipherChoice {
     ChaChaPoly,
+    #[cfg(feature = "xchachapoly")]
+    XChaChaPoly,
     AESGCM,
 }
 
@@ -66,6 +68,8 @@ impl FromStr for CipherChoice {
         use self::CipherChoice::*;
         match s {
             "ChaChaPoly" => Ok(ChaChaPoly),
+            #[cfg(feature = "xchachapoly")]
+            "XChaChaPoly" => Ok(XChaChaPoly),
             "AESGCM" => Ok(AESGCM),
             _ => bail!(PatternProblem::UnsupportedCipherType),
         }

--- a/src/resolvers/ring.rs
+++ b/src/resolvers/ring.rs
@@ -37,6 +37,8 @@ impl CryptoResolver for RingResolver {
         match *choice {
             CipherChoice::AESGCM => Some(Box::new(CipherAESGCM::default())),
             CipherChoice::ChaChaPoly => Some(Box::new(CipherChaChaPoly::default())),
+            #[cfg(feature = "xchachapoly")]
+            CipherChoice::XChaChaPoly => None,
         }
     }
 }


### PR DESCRIPTION
This adds the `XChaChaPoly` cipher to snow. The crypto used is the [chacha20poly1305](https://crates.io/crates/chacha20poly1305) crate, which also has a dependency on the [aead](https://crates.io/crates/aead) crate. I added a simple test that follows the ChaChaPoly test. Likely more tests are needed.

I notices that [XChaChaPoly is missing](https://github.com/mcginty/snow/issues/71) when trying to handshake with a [hypercore-protocol stream from nodejs](https://github.com/datrs/hypercore/issues/92)