### PR TITLE
Add function returning whether it is our turn to write during handshake

### DIFF
--- a/src/handshakestate.rs
+++ b/src/handshakestate.rs
@@ -502,6 +502,11 @@ impl HandshakeState {
         self.pattern_position == self.message_patterns.len()
     }
 
+    /// Check whether it is our turn to send in the handshake state machine
+    pub fn is_our_turn_to_send(&self) -> bool {
+        self.my_turn
+    }
+
     /// Convert this `HandshakeState` into a `TransportState` with an internally stored nonce.
     pub fn into_transport_mode(self) -> Result<TransportState, Error> {
         Ok(self.try_into()?)

--- a/src/handshakestate.rs
+++ b/src/handshakestate.rs
@@ -503,7 +503,7 @@ impl HandshakeState {
     }
 
     /// Check whether it is our turn to send in the handshake state machine
-    pub fn is_our_turn_to_send(&self) -> bool {
+    pub fn is_my_turn(&self) -> bool {
         self.my_turn
     }
 


### PR DESCRIPTION
This is useful for situations when a handshake is being set up asyncronously
by polling. When poll is called, the function might not have access to
global state to keep track of which party needs to send next. Querying the
state machine would be useful in such a situation.