### PR TITLE
Switch from chacha20-poly1305-aead to chacha20poly1305 in the default resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ edition = "2018"
 # and -accelerated suffix means that this resolver will be the default used by the Builder.
 [features]
 default = ["default-resolver"]
-nightly = ["blake2/simd_opt", "chacha20-poly1305-aead/simd_opt", "x25519-dalek/nightly", "subtle/nightly"]
-default-resolver = ["chacha20-poly1305-aead", "blake2", "sha2", "x25519-dalek", "rand"]
+nightly = ["blake2/simd_opt", "x25519-dalek/nightly", "subtle/nightly"]
+default-resolver = ["chacha20poly1305", "blake2", "sha2", "x25519-dalek", "rand"]
 ring-resolver = ["ring"]
 ring-accelerated = ["ring-resolver", "default-resolver"]
 vector-tests = []
@@ -38,7 +38,7 @@ rand_core = "0.5"
 subtle = "2.1"
 
 # default crypto provider
-chacha20-poly1305-aead = { version = "0.1", optional = true }
+chacha20poly1305 = { version = "0.3", optional = true }
 blake2 = { version = "0.8", optional = true }
 rand = { version = "0.7", optional = true }
 sha2 = { version = "0.8", optional = true }


### PR DESCRIPTION
Hi, [`chacha20-poly1305-aead`](https://crates.io/crates/chacha20-poly1305-aead) hasn't been updated for 4 years, so we should switch to [`chacha20poly1305`](https://crates.io/crates/chacha20poly1305) which is actively maintained.