### PR TITLE
Expose the raw split result

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ libsodium-accelerated = ["libsodium-resolver", "default-resolver"]
 vector-tests = []
 hfs = []
 pqclean_kyber1024 = ["pqcrypto-kyber", "pqcrypto-traits", "hfs", "default-resolver"]
+risky-raw-split = []
 
 [[bench]]
 name = "benches"

--- a/src/handshakestate.rs
+++ b/src/handshakestate.rs
@@ -513,10 +513,13 @@ impl HandshakeState {
     /// This returns raw key material so it should be used with care. The "risky-raw-split"
     /// feature has to be enabled to use this function.
     #[cfg(feature = "risky-raw-split")]
-    pub fn dangerously_get_raw_split(&mut self) -> (Vec<u8>, Vec<u8>) {
+    pub fn dangerously_get_raw_split(&mut self) -> ([u8; CIPHERKEYLEN], [u8; CIPHERKEYLEN]) {
         let mut output = ([0u8; MAXHASHLEN], [0u8; MAXHASHLEN]);
         self.symmetricstate.split_raw(&mut output.0, &mut output.1);
-        (output.0[..CIPHERKEYLEN].to_vec(), output.1[..CIPHERKEYLEN].to_vec())
+        (
+            output.0[..CIPHERKEYLEN].try_into().unwrap(),
+            output.1[..CIPHERKEYLEN].try_into().unwrap()
+        )
     }
 
     /// Convert this `HandshakeState` into a `TransportState` with an internally stored nonce.

--- a/src/handshakestate.rs
+++ b/src/handshakestate.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "risky-raw-split")]
+use crate::constants::{CIPHERKEYLEN, MAXHASHLEN};
 #[cfg(feature = "hfs")]
 use crate::constants::{MAXKEMCTLEN, MAXKEMPUBLEN, MAXKEMSSLEN};
 #[cfg(feature = "hfs")]
@@ -504,6 +506,17 @@ impl HandshakeState {
     /// Check whether it is our turn to send in the handshake state machine
     pub fn is_my_turn(&self) -> bool {
         self.my_turn
+    }
+
+    /// Perform the split calculation and return the resulting keys.
+    ///
+    /// This returns raw key material so it should be used with care. The "risky-raw-split"
+    /// feature has to be enabled to use this function.
+    #[cfg(feature = "risky-raw-split")]
+    pub fn dangerously_get_raw_split(&mut self) -> (Vec<u8>, Vec<u8>) {
+        let mut output = ([0u8; MAXHASHLEN], [0u8; MAXHASHLEN]);
+        self.symmetricstate.split_raw(&mut output.0, &mut output.1);
+        (output.0[..CIPHERKEYLEN].to_vec(), output.1[..CIPHERKEYLEN].to_vec())
     }
 
     /// Convert this `HandshakeState` into a `TransportState` with an internally stored nonce.

--- a/src/symmetricstate.rs
+++ b/src/symmetricstate.rs
@@ -122,18 +122,15 @@ impl SymmetricState {
     }
 
     pub fn split(&mut self, child1: &mut CipherState, child2: &mut CipherState) {
-        let hash_len = self.hasher.hash_len();
         let mut hkdf_output = ([0u8; MAXHASHLEN], [0u8; MAXHASHLEN]);
-        self.hasher.hkdf(
-            &self.inner.ck[..hash_len],
-            &[0u8; 0],
-            2,
-            &mut hkdf_output.0,
-            &mut hkdf_output.1,
-            &mut [],
-        );
+        self.split_raw(&mut hkdf_output.0, &mut hkdf_output.1);
         child1.set(&hkdf_output.0[..CIPHERKEYLEN], 0);
         child2.set(&hkdf_output.1[..CIPHERKEYLEN], 0);
+    }
+
+    pub fn split_raw(&mut self, mut out1: &mut [u8], mut out2: &mut [u8]) {
+        let hash_len = self.hasher.hash_len();
+        self.hasher.hkdf(&self.inner.ck[..hash_len], &[0u8; 0], 2, &mut out1, &mut out2, &mut []);
     }
 
     pub(crate) fn checkpoint(&mut self) -> SymmetricStateData {


### PR DESCRIPTION
Some protocols like [hypercore-protocol](https://github.com/mafintosh/hypercore-protocol) follow the Noise framework for the handshake, but then use a different transport encryption (e.g. streaming Salsa20 without delimited messages) where the keys are the result of the Split at the end of the Noise handshake. This PR adds a public method to access the raw key material that is the result of the Split operation, so that it can be passed as keys into other ciphers.

With this PR it was straightforward to implement the hypercore-protocol transport with snow.
An alternative would be to make the CipherState public, and add an option to the Handshakestate and Builder to pass CipherState structs created outside of snow into the builder, which would then receive the key material after the split operation.