### PR TITLE
Re-add AES-GCM to default resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ edition = "2018"
 # and -accelerated suffix means that this resolver will be the default used by the Builder.
 [features]
 default = ["default-resolver"]
+default-resolver = ["aes-gcm", "chacha20poly1305", "blake2", "sha2", "x25519-dalek", "rand"]
 nightly = ["blake2/simd_opt", "x25519-dalek/nightly", "subtle/nightly"]
-default-resolver = ["chacha20poly1305", "blake2", "sha2", "x25519-dalek", "rand"]
 ring-resolver = ["ring"]
 ring-accelerated = ["ring-resolver", "default-resolver"]
 vector-tests = []
@@ -38,6 +38,7 @@ rand_core = "0.5"
 subtle = "2.1"
 
 # default crypto provider
+aes-gcm = { version = "0.3", optional = true }
 chacha20poly1305 = { version = "0.3", optional = true }
 blake2 = { version = "0.8", optional = true }
 rand = { version = "0.7", optional = true }
@@ -56,7 +57,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 hex = "0.4"
-lazy_static = "1.3"
+lazy_static = "1.4"
 
 [build-dependencies]
 rustc_version = "0.2"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ However, a not all features have been implemented yet (pull requests welcome):
 Cryptographic providers are swappable through `Builder::with_resolver()`, but by default it chooses select, artisanal
 pure-Rust implementations (see `Cargo.toml` for a quick overview).
 
-### Providers
+### Other Providers
 
 #### ring
 
@@ -64,7 +64,7 @@ If you enable the `ring-accelerated` feature, Snow will default to choosing `rin
 | CSPRNG     | ✔       | ✔    |
 | 25519      | ✔       | ✔    |
 | 448        |         |      |
-| AESGCM     |         | ✔    |
+| AESGCM     | ✔       | ✔    |
 | ChaChaPoly | ✔       | ✔    |
 | SHA256     | ✔       | ✔    |
 | SHA512     | ✔       | ✔    |

--- a/tests/vectors.rs
+++ b/tests/vectors.rs
@@ -253,17 +253,11 @@ fn test_vectors_from_json(json: &str) {
     for vector in test_vectors.vectors {
         let params: NoiseParams = vector.protocol_name.parse().unwrap();
 
-        if !cfg!(feature = "ring-accelerated") {
-            if params.cipher == CipherChoice::AESGCM {
-                ignored += 1;
-                continue
-            }
-        }
-
         if params.dh == DHChoice::Ed448 {
             ignored += 1;
             continue;
         }
+
         let (init, resp) = match build_session_pair(&vector) {
             Ok((init, resp)) => (init, resp),
             Err(s) => {


### PR DESCRIPTION
This PR is pretty straightforward, it re-adds AES-GCM support back to snow's default resolver. It was originally removed back when `rust-crypto` was replaced by `RustCrypto` because there was not a suitable replacement at the time. `RustCrypto`'s aes-gcm implementation was picked for this.

All the tests and vectors pass right now, and I created a few new sanity tests to ensure coverage across both AES-GCM and ChaChaPoly usage.