### PR TITLE
Replace arrayref with TryInto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ harness = false
 travis-ci = { repository = "mcginty/snow", branch = "master" }
 
 [dependencies]
-arrayref = "0.3.5"
 rand_core = "0.5"
 subtle = "2.1"
 

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -1,4 +1,4 @@
-use arrayref::array_ref;
+use core::convert::TryInto;
 use blake2::Blake2b;
 use blake2::Blake2s;
 use aes_gcm;
@@ -111,8 +111,7 @@ impl Random for OsRng {}
 impl Dh for Dh25519 {
 
     fn name(&self) -> &'static str {
-        static NAME: &str = "25519";
-        NAME
+        "25519"
     }
 
     fn pub_len(&self) -> usize {
@@ -142,7 +141,7 @@ impl Dh for Dh25519 {
     }
 
     fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), ()> {
-        let result = x25519::x25519(self.privkey, *array_ref![pubkey, 0, 32]);
+        let result = x25519::x25519(self.privkey, pubkey[..32].try_into().unwrap());
         copy_slices!(&result, out);
         Ok(())
     }


### PR DESCRIPTION
Title pretty much says it all. We were only using on one line, to get the first 32 bytes of a key for Diffe-Hellman 25519. Since Rust 1.34, TryInto works for turning slices into arrays, as noted [here](https://github.com/droundy/arrayref/issues/18). 32 bytes is the limit until const generics, but conveniently 32 is all we need for this.

Overall, seems a tad overkill to bring in an entire library for one line that Rust core functionality offers.