### PR TITLE
Update subtle version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ travis-ci = { repository = "mcginty/snow", branch = "master" }
 [dependencies]
 arrayref = "0.3.5"
 rand_core = "0.5"
-subtle = "2.1"
+subtle = "2.2"
 
 # default crypto provider
 aes-gcm = { version = "0.3", optional = true }


### PR DESCRIPTION
Following up on #79, this PR updates `subtle` to version 2.2. The biggest improvement here is gaining the ability to hide values from the optimizer when not running Nightly versions of Rust, improving security against timing attacks regardless of what toolchain is used.