### PR TITLE
Adds Curve448

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 # and -accelerated suffix means that this resolver will be the default used by the Builder.
 [features]
 default = ["default-resolver"]
-default-resolver = ["aes-gcm", "chacha20poly1305", "blake2", "sha2", "x25519-dalek", "rand"]
+default-resolver = ["aes-gcm", "chacha20poly1305", "blake2", "sha2", "x25519-dalek", "x448","rand"]
 nightly = ["blake2/simd_opt", "x25519-dalek/nightly", "subtle/nightly"]
 ring-resolver = ["ring"]
 ring-accelerated = ["ring-resolver", "default-resolver"]
@@ -47,6 +47,7 @@ blake2 = { version = "0.8", optional = true }
 rand = { version = "0.7", optional = true }
 sha2 = { version = "0.8", optional = true }
 x25519-dalek = { version = "0.6", optional = true }
+x448 = { version = "0.6", optional = true }
 pqcrypto-kyber = { version = "0.6", optional = true }
 pqcrypto-traits = { version = "0.3", optional = true }
 

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -35,7 +35,7 @@ impl FromStr for BaseChoice {
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub enum DHChoice {
     Curve25519,
-    Ed448,
+    Curve448,
 }
 
 impl FromStr for DHChoice {
@@ -45,7 +45,7 @@ impl FromStr for DHChoice {
         use self::DHChoice::*;
         match s {
             "25519" => Ok(Curve25519),
-            "448" => Ok(Ed448),
+            "448" => Ok(Curve448),
             _ => bail!(PatternProblem::UnsupportedDhType),
         }
     }

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -14,6 +14,7 @@ use pqcrypto_traits::kem::{Ciphertext, PublicKey, SecretKey, SharedSecret};
 use rand::rngs::OsRng;
 use sha2::{Digest, Sha256, Sha512};
 use x25519_dalek as x25519;
+use x448;
 
 use super::CryptoResolver;
 #[cfg(feature = "pqclean_kyber1024")]
@@ -40,7 +41,7 @@ impl CryptoResolver for DefaultResolver {
     fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<dyn Dh>> {
         match *choice {
             DHChoice::Curve25519 => Some(Box::new(Dh25519::default())),
-            _ => None,
+            DHChoice::Curve448 => Some(Box::new(Dh448::default())),
         }
     }
 
@@ -75,6 +76,16 @@ impl CryptoResolver for DefaultResolver {
 struct Dh25519 {
     privkey: [u8; 32],
     pubkey:  [u8; 32],
+}
+/// Wraps x448 [crate-crypto].
+struct Dh448 {
+    privkey: [u8; 56],
+    pubkey:  [u8; 56],
+}
+impl Default for Dh448 {
+    fn default() -> Dh448 {
+        Dh448 { privkey: [0u8; 56], pubkey: [0u8; 56] }
+    }
 }
 
 /// Wraps `aes-gcm`'s AES256-GCM implementation.
@@ -158,6 +169,45 @@ impl Dh for Dh25519 {
 
     fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), ()> {
         let result = x25519::x25519(self.privkey, pubkey[..32].try_into().unwrap());
+        copy_slices!(&result, out);
+        Ok(())
+    }
+}
+
+impl Dh for Dh448 {
+    fn name(&self) -> &'static str {
+        "448"
+    }
+
+    fn pub_len(&self) -> usize {
+        56
+    }
+
+    fn priv_len(&self) -> usize {
+        56
+    }
+
+    fn set(&mut self, privkey: &[u8]) {
+        copy_slices!(privkey, &mut self.privkey);
+        self.pubkey = x448::x448_unchecked(self.privkey, x448::X448_BASEPOINT_BYTES);
+    }
+
+    fn generate(&mut self, rng: &mut dyn Random) {
+        rng.fill_bytes(&mut self.privkey);
+        self.pubkey = x448::x448_unchecked(self.privkey, x448::X448_BASEPOINT_BYTES);
+    }
+
+    fn pubkey(&self) -> &[u8] {
+        &self.pubkey
+    }
+
+    fn privkey(&self) -> &[u8] {
+        &self.privkey
+    }
+
+    fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), ()> {
+        let pub_key = x448::PublicKey::from_bytes_unchecked(pubkey).unwrap();
+        let result = x448::x448_unchecked(self.privkey, *pub_key.as_bytes());
         copy_slices!(&result, out);
         Ok(())
     }
@@ -529,7 +579,6 @@ mod tests {
 
     use self::hex::FromHex;
     use super::*;
-    use crate::types::*;
 
     #[test]
     fn test_sha256() {
@@ -613,6 +662,24 @@ mod tests {
         assert!(
             hex::encode(output)
                 == "c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552"
+        );
+    }
+    #[test]
+    fn test_curve448() {
+        // Curve448 test - draft-curves-10
+        let mut keypair: Dh448 = Default::default();
+        let scalar =
+            Vec::<u8>::from_hex("3d262fddf9ec8e88495266fea19a34d28882acef045104d0d1aae121700a779c984c24f8cdd78fbff44943eba368f54b29259a4f1c600ad3")
+                .unwrap();
+        copy_slices!(&scalar, &mut keypair.privkey);
+        let public =
+            Vec::<u8>::from_hex("06fce640fa3487bfda5f6cf2d5263f8aad88334cbd07437f020f08f9814dc031ddbdc38c19c6da2583fa5429db94ada18aa7a7fb4ef8a086")
+                .unwrap();
+        let mut output = [0u8; 56];
+        keypair.dh(&public, &mut output).unwrap();
+        assert_eq!(
+            hex::encode(&output[..]),
+                 "ce3e4ff95a60dc6697da1db1d85e6afbdf79b50a2412d7546d5f239fe14fbaadeb445fc66a01b0779d98223961111e21766282f73dd96b6f"
         );
     }
 

--- a/tests/vectors.rs
+++ b/tests/vectors.rs
@@ -259,15 +259,9 @@ fn test_vectors_from_json(json: &str) {
 
     let mut passes = 0;
     let mut fails = 0;
-    let mut ignored = 0;
 
     for vector in test_vectors.vectors {
         let params: NoiseParams = vector.protocol_name.parse().unwrap();
-
-        if params.dh == DHChoice::Ed448 {
-            ignored += 1;
-            continue;
-        }
 
         let (init, resp) = match build_session_pair(&vector) {
             Ok((init, resp)) => (init, resp),
@@ -299,7 +293,6 @@ fn test_vectors_from_json(json: &str) {
     }
 
     println!("\n{}/{} passed", passes, passes + fails);
-    println!("* ignored {} unsupported variants", ignored);
     if fails > 0 {
         panic!("at least one vector failed.");
     }


### PR DESCRIPTION
This PR:

- Renames Ed448 to Curve448.

- Adds X448 from crate-crypto : (unchecked API)

- Uncomments the code that was ignoring the tests for Curve448.

Notes:

- The unchecked API does not check for low order points. This was done to mirror the default X22519 implementation. The check can be added back by removing the `unchecked` keyword from the functions.

- There is one unwrap in the `dh` method when `from_bytes_unchecked` is called. This will return None, if you do not pass 56 bytes. This should mirror the try_into().unwrap() method.

- The underlying EC library for X448 does not implement a fixed base scalar mul, so benchmarks for key generation will become more efficient when this implemented, without changing the API. 