### PR TITLE
Upgrade RustCrypto crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ rand_core = "0.5"
 subtle = "2.2"
 
 # default crypto provider
-aes-gcm = { version = "0.5", optional = true }
-chacha20poly1305 = { version = "0.4", optional = true }
-blake2 = { version = "0.8", optional = true }
+aes-gcm = { version = "0.6", optional = true }
+chacha20poly1305 = { version = "0.5", optional = true }
+blake2 = { version = "0.9", optional = true }
 rand = { version = "0.7", optional = true }
-sha2 = { version = "0.8", optional = true }
+sha2 = { version = "0.9", optional = true }
 x25519-dalek = { version = "0.6", optional = true }
 pqcrypto-kyber = { version = "0.6", optional = true }
 pqcrypto-traits = { version = "0.3", optional = true }


### PR DESCRIPTION
Performs the following crate upgrades:

- `aes-gcm` v0.6
- `chacha20poly1305` v0.5
- `blake2` v0.9
- `sha2` v0.9

This commit does the minimal work to perform the update, however there are some additional optimizations possible (e.g. not making unnecessary copies of keys)