### PR TITLE
Upgrade RustCrypto and dalek-cryptography crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,12 @@ rand_core = "0.5"
 subtle = "2.2"
 
 # default crypto provider
-aes-gcm = { version = "0.6", optional = true }
-chacha20poly1305 = { version = "0.5", optional = true }
+aes-gcm = { version = "0.7", optional = true }
+chacha20poly1305 = { version = "0.6", optional = true }
 blake2 = { version = "0.9", optional = true }
 rand = { version = "0.7", optional = true }
 sha2 = { version = "0.9", optional = true }
-x25519-dalek = { version = "0.6", optional = true }
+x25519-dalek = { version = "1.1", optional = true }
 pqcrypto-kyber = { version = "0.6", optional = true }
 pqcrypto-traits = { version = "0.3", optional = true }
 
@@ -72,4 +72,3 @@ rustc_version = "0.2"
 features = [ "ring-resolver", "libsodium-resolver" ]
 all-features = false
 no-default-features = false
-


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

I recommend to manage simple dependency upgrades by using `dependabot` directly.