### PR TITLE
Bump `aes-gcm` to v0.8; `chacha20poly1305` to v0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ rand_core = "0.5"
 subtle = "2.2"
 
 # default crypto provider
-aes-gcm = { version = "0.7", optional = true }
-chacha20poly1305 = { version = "0.6", optional = true }
+aes-gcm = { version = "0.8", optional = true }
+chacha20poly1305 = { version = "0.7", optional = true }
 blake2 = { version = "0.9", optional = true }
 rand = { version = "0.7", optional = true }
 sha2 = { version = "0.9", optional = true }


### PR DESCRIPTION
These releases use the new `cipher` crate:

https://github.com/RustCrypto/traits/tree/master/cipher

Otherwise they're drop-in replacements.