### PR TITLE
Remove more unwraps

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -105,6 +105,8 @@ pub enum StateProblem {
     HandshakeAlreadyFinished,
     OneWay,
     StatelessTransportMode,
+    /// The nonce counter attempted to go higher than (2^64) - 1
+    Exhausted,
 }
 
 impl From<StateProblem> for Error {

--- a/src/resolvers/libsodium.rs
+++ b/src/resolvers/libsodium.rs
@@ -4,6 +4,7 @@ use byteorder::{ByteOrder, LittleEndian};
 
 use super::CryptoResolver;
 use crate::{
+    Error,
     params::{CipherChoice, DHChoice, HashChoice},
     types::{Cipher, Dh, Hash, Random},
 };
@@ -108,7 +109,7 @@ impl Dh for SodiumDh25519 {
         &self.privkey[0..32]
     }
 
-    fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), ()> {
+    fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), Error> {
         let pubkey = sodium_curve25519::GroupElement::from_slice(&pubkey[0..32])
             .expect("Can't construct public key for Dh25519");
         let result = sodium_curve25519::scalarmult(&self.privkey, &pubkey);
@@ -118,7 +119,7 @@ impl Dh for SodiumDh25519 {
                 copy_slices!(buf.as_ref(), out);
                 Ok(())
             },
-            Err(_) => Err(()),
+            Err(_) => Err(Error::Dh),
         }
     }
 }
@@ -163,7 +164,7 @@ impl Cipher for SodiumChaChaPoly {
         authtext: &[u8],
         ciphertext: &[u8],
         out: &mut [u8],
-    ) -> Result<usize, ()> {
+    ) -> Result<usize, Error> {
         let mut nonce_bytes = [0u8; 12];
         LittleEndian::write_u64(&mut nonce_bytes[4..], nonce);
         let nonce = sodium_chacha20poly1305::Nonce(nonce_bytes);
@@ -175,7 +176,7 @@ impl Cipher for SodiumChaChaPoly {
                 copy_slices!(&buf, out);
                 Ok(buf.len())
             },
-            Err(_) => Err(()),
+            Err(_) => Err(Error::Decrypt),
         }
     }
 }

--- a/src/resolvers/ring.rs
+++ b/src/resolvers/ring.rs
@@ -1,6 +1,7 @@
 use super::CryptoResolver;
 use crate::{
     constants::TAGLEN,
+    Error,
     params::{CipherChoice, DHChoice, HashChoice},
     types::{Cipher, Dh, Hash, Random},
 };
@@ -125,7 +126,7 @@ impl Cipher for CipherAESGCM {
         authtext: &[u8],
         ciphertext: &[u8],
         out: &mut [u8],
-    ) -> Result<usize, ()> {
+    ) -> Result<usize, Error> {
         let mut nonce_bytes = [0u8; 12];
         copy_slices!(&nonce.to_be_bytes(), &mut nonce_bytes[4..]);
         let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
@@ -137,7 +138,7 @@ impl Cipher for CipherAESGCM {
             let len = self
                 .key
                 .open_in_place(nonce, aead::Aad::from(authtext), in_out)
-                .map_err(|_| ())?
+                .map_err(|_| Error::Decrypt)?
                 .len();
 
             Ok(len)
@@ -147,7 +148,8 @@ impl Cipher for CipherAESGCM {
             let out0 = self
                 .key
                 .open_in_place(nonce, aead::Aad::from(authtext), &mut in_out)
-                .map_err(|_| ())?;
+                .map_err(|_| Error::Decrypt)?;
+            
             out[..out0.len()].copy_from_slice(out0);
             Ok(out0.len())
         }
@@ -203,7 +205,7 @@ impl Cipher for CipherChaChaPoly {
         authtext: &[u8],
         ciphertext: &[u8],
         out: &mut [u8],
-    ) -> Result<usize, ()> {
+    ) -> Result<usize, Error> {
         let mut nonce_bytes = [0u8; 12];
         copy_slices!(&nonce.to_le_bytes(), &mut nonce_bytes[4..]);
         let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
@@ -215,7 +217,7 @@ impl Cipher for CipherChaChaPoly {
             let len = self
                 .key
                 .open_in_place(nonce, aead::Aad::from(authtext), in_out)
-                .map_err(|_| ())?
+                .map_err(|_| Error::Decrypt)?
                 .len();
 
             Ok(len)
@@ -225,7 +227,8 @@ impl Cipher for CipherChaChaPoly {
             let out0 = self
                 .key
                 .open_in_place(nonce, aead::Aad::from(authtext), &mut in_out)
-                .map_err(|_| ())?;
+                .map_err(|_| Error::Decrypt)?;
+            
             out[..out0.len()].copy_from_slice(out0);
             Ok(out0.len())
         }

--- a/src/stateless_transportstate.rs
+++ b/src/stateless_transportstate.rs
@@ -78,9 +78,7 @@ impl StatelessTransportState {
     /// Will result in `Error::Decrypt` if the contents couldn't be decrypted and/or the
     /// authentication tag didn't verify.
     ///
-    /// # Panics
-    ///
-    /// This function will panic if there is no key.
+    /// Will result in `StateProblem::Exhausted` if the max nonce overflows.
     pub fn read_message(
         &self,
         nonce: u64,
@@ -91,7 +89,7 @@ impl StatelessTransportState {
             bail!(StateProblem::OneWay);
         }
         let cipher = if self.initiator { &self.cipherstates.1 } else { &self.cipherstates.0 };
-        cipher.decrypt(nonce, payload, message).map_err(|_| Error::Decrypt)
+        cipher.decrypt(nonce, payload, message)
     }
 
     /// Generates a new key for the egress symmetric cipher according to Section 4.2

--- a/src/symmetricstate.rs
+++ b/src/symmetricstate.rs
@@ -106,13 +106,13 @@ impl SymmetricState {
         Ok(output_len)
     }
 
-    pub fn decrypt_and_mix_hash(&mut self, data: &[u8], out: &mut [u8]) -> Result<usize, ()> {
+    pub fn decrypt_and_mix_hash(&mut self, data: &[u8], out: &mut [u8]) -> Result<usize, Error> {
         let hash_len = self.hasher.hash_len();
         let payload_len = if self.inner.has_key {
             self.cipherstate.decrypt_ad(&self.inner.h[..hash_len], data, out)?
         } else {
             if out.len() < data.len() {
-                return Err(());
+                return Err(Error::Decrypt);
             }
             copy_slices!(data, out);
             data.len()

--- a/src/transportstate.rs
+++ b/src/transportstate.rs
@@ -74,16 +74,15 @@ impl TransportState {
     /// Will result in `Error::Decrypt` if the contents couldn't be decrypted and/or the
     /// authentication tag didn't verify.
     ///
-    /// # Panics
-    ///
-    /// This function will panic if there is no key, or if there is a nonce overflow.
+    /// Will result in `StateProblem::Exhausted` if the max nonce overflows.
     pub fn read_message(&mut self, payload: &[u8], message: &mut [u8]) -> Result<usize, Error> {
         if self.initiator && self.pattern.is_oneway() {
             bail!(StateProblem::OneWay);
         }
         let cipher =
             if self.initiator { &mut self.cipherstates.1 } else { &mut self.cipherstates.0 };
-        cipher.decrypt(payload, message).map_err(|_| Error::Decrypt)
+        
+        cipher.decrypt(payload, message)
     }
 
     /// Generates a new key for the egress symmetric cipher according to Section 4.2

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! The traits for cryptographic implementations that can be used by Noise.
 
-use crate::constants::{CIPHERKEYLEN, MAXBLOCKLEN, MAXHASHLEN, TAGLEN};
+use crate::{constants::{CIPHERKEYLEN, MAXBLOCKLEN, MAXHASHLEN, TAGLEN}, Error};
 use rand_core::{CryptoRng, RngCore};
 
 /// CSPRNG operations
@@ -30,7 +30,7 @@ pub trait Dh: Send + Sync {
     fn privkey(&self) -> &[u8];
 
     /// Calculate a Diffie-Hellman exchange.
-    fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), ()>;
+    fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), Error>;
 }
 
 /// Cipher operations
@@ -51,7 +51,7 @@ pub trait Cipher: Send + Sync {
         authtext: &[u8],
         ciphertext: &[u8],
         out: &mut [u8],
-    ) -> Result<usize, ()>;
+    ) -> Result<usize, Error>;
 
     /// Rekey according to Section 4.2 of the Noise Specification, with a default
     /// implementation guaranteed to be secure for all ciphers.


### PR DESCRIPTION
I went through and checked all of the `.unwrap()` and `.expect()` calls in the code and removed the ones that *could* fail, like the nonce counter overflowing. Instead, errors are returned. Calls that `snow` makes internally and things like encryption were left as panicking since they can't fail unless theres a programming bug somewhere in the library.

While I was at it, I cleaned up the error handling a bit to be more Rust-y. 

I ran `./ci-tests.sh` on both stable and nightly and all the tests compiled and passed.

Closes #3

~~Note: This branches off #102 so the two commits from there are here too. I'll rebase this PR if needed.~~