### PR TITLE
Cargo.toml: Update rand and rand_core to 0.8 and 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,14 +37,14 @@ harness = false
 travis-ci = { repository = "mcginty/snow", branch = "master" }
 
 [dependencies]
-rand_core = "0.5"
+rand_core = "0.6"
 subtle = "2.2"
 
 # default crypto provider
 aes-gcm = { version = "0.8", optional = true }
 chacha20poly1305 = { version = "0.7", optional = true }
 blake2 = { version = "0.9", optional = true }
-rand = { version = "0.7", optional = true }
+rand = { version = "0.8", optional = true }
 sha2 = { version = "0.9", optional = true }
 x25519-dalek = { version = "1.1", optional = true }
 pqcrypto-kyber = { version = "0.6", optional = true }


### PR DESCRIPTION
See [rand changelog](https://github.com/rust-random/rand/blob/master/CHANGELOG.md) and [rand_core changelog](https://github.com/rust-random/rand/blob/master/rand_core/CHANGELOG.md).

Thanks for maintaining `snow`!