### PR TITLE
.github/: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Maintaining multiple open source projects, I found [Dependabot](https://dependabot.com/) very helpful. It will continuously monitor all dependencies and automatically create pull requests once newer versions are available. Note, given that `snow` is a library, Dependabot will not update minor and patch versions for crates >= `1.0` nor patch versions for crates < `1.0`. This keeps the overall noise vs. signal ratio low while still allowing binaries to stay up-to-date with latest (security) patches. See [documentation](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy) for details.

In case you would like to enable Dependabot for `snow`, you only need to merge this pull request. Feel free to just close this pull request otherwise.