### PR TITLE
fix doc references to parameters and grammar inconsistencies

### DIFF
--- a/src/handshakestate.rs
+++ b/src/handshakestate.rs
@@ -195,9 +195,9 @@ impl HandshakeState {
     }
 
     /// Construct a message from `payload` (and pending handshake tokens if in handshake state),
-    /// and writes it to the `message` buffer.
+    /// and write it to the `message` buffer.
     ///
-    /// Returns the size of the written payload.
+    /// Returns the number of bytes written to `message`.
     ///
     /// # Errors
     ///
@@ -320,9 +320,9 @@ impl HandshakeState {
         Ok(byte_index)
     }
 
-    /// Reads a noise message from `input`
+    /// Read a noise message from `message` and write the payload to the `payload` buffer.
     ///
-    /// Returns the size of the payload written to `payload`.
+    /// Returns the number of bytes written to `payload`.
     ///
     /// # Errors
     ///

--- a/src/stateless_transportstate.rs
+++ b/src/stateless_transportstate.rs
@@ -45,9 +45,9 @@ impl StatelessTransportState {
     }
 
     /// Construct a message from `payload` (and pending handshake tokens if in handshake state),
-    /// and writes it to the `output` buffer.
+    /// and write it to the `message` buffer.
     ///
-    /// Returns the size of the written payload.
+    /// Returns the number of bytes written to `message`.
     ///
     /// # Errors
     ///
@@ -69,9 +69,9 @@ impl StatelessTransportState {
         Ok(cipher.encrypt(nonce, payload, message)?)
     }
 
-    /// Reads a noise message from `input`
+    /// Read a noise message from `message` and write the payload to the `payload` buffer.
     ///
-    /// Returns the size of the payload written to `payload`.
+    /// Returns the number of bytes written to `payload`.
     ///
     /// # Errors
     ///
@@ -84,17 +84,17 @@ impl StatelessTransportState {
     pub fn read_message(
         &self,
         nonce: u64,
-        payload: &[u8],
-        message: &mut [u8],
+        message: &[u8],
+        payload: &mut [u8],
     ) -> Result<usize, Error> {
         if self.initiator && self.pattern.is_oneway() {
             bail!(StateProblem::OneWay);
         }
         let cipher = if self.initiator { &self.cipherstates.1 } else { &self.cipherstates.0 };
-        cipher.decrypt(nonce, payload, message).map_err(|_| Error::Decrypt)
+        cipher.decrypt(nonce, message, payload).map_err(|_| Error::Decrypt)
     }
 
-    /// Generates a new key for the egress symmetric cipher according to Section 4.2
+    /// Generate a new key for the egress symmetric cipher according to Section 4.2
     /// of the Noise Specification. Synchronizing timing of rekey between initiator and
     /// responder is the responsibility of the application, as described in Section 11.3
     /// of the Noise Specification.
@@ -106,7 +106,7 @@ impl StatelessTransportState {
         }
     }
 
-    /// Generates a new key for the ingress symmetric cipher according to Section 4.2
+    /// Generate a new key for the ingress symmetric cipher according to Section 4.2
     /// of the Noise Specification. Synchronizing timing of rekey between initiator and
     /// responder is the responsibility of the application, as described in Section 11.3
     /// of the Noise Specification.


### PR DESCRIPTION
I noticed a few references in the docs to non-existent parameters. While I was at it, I found some inconsistencies, e.g. a few instances of non-imperative language in the short function summaries (inconsistent with the others in those modules).