### PR TITLE
Support ad in stateless transport.

### DIFF
--- a/src/cipherstate.rs
+++ b/src/cipherstate.rs
@@ -144,14 +144,6 @@ impl StatelessCipherState {
         self.cipher.decrypt(nonce, authtext, ciphertext, out)
     }
 
-    pub fn encrypt(&self, nonce: u64, plaintext: &[u8], out: &mut [u8]) -> Result<usize, Error> {
-        self.encrypt_ad(nonce, &[], plaintext, out)
-    }
-
-    pub fn decrypt(&self, nonce: u64, ciphertext: &[u8], out: &mut [u8]) -> Result<usize, ()> {
-        self.decrypt_ad(nonce, &[], ciphertext, out)
-    }
-
     pub fn rekey(&mut self) {
         self.cipher.rekey()
     }

--- a/src/stateless_transportstate.rs
+++ b/src/stateless_transportstate.rs
@@ -58,6 +58,7 @@ impl StatelessTransportState {
         nonce: u64,
         payload: &[u8],
         message: &mut [u8],
+        ad: &[u8],
     ) -> Result<usize, Error> {
         if !self.initiator && self.pattern.is_oneway() {
             bail!(StateProblem::OneWay);
@@ -66,7 +67,7 @@ impl StatelessTransportState {
         }
 
         let cipher = if self.initiator { &self.cipherstates.0 } else { &self.cipherstates.1 };
-        Ok(cipher.encrypt(nonce, payload, message)?)
+        Ok(cipher.encrypt_ad(nonce, ad, payload, message)?)
     }
 
     /// Reads a noise message from `input`
@@ -86,12 +87,13 @@ impl StatelessTransportState {
         nonce: u64,
         payload: &[u8],
         message: &mut [u8],
+        ad: &[u8],
     ) -> Result<usize, Error> {
         if self.initiator && self.pattern.is_oneway() {
             bail!(StateProblem::OneWay);
         }
         let cipher = if self.initiator { &self.cipherstates.1 } else { &self.cipherstates.0 };
-        cipher.decrypt(nonce, payload, message).map_err(|_| Error::Decrypt)
+        cipher.decrypt_ad(nonce, ad, payload, message).map_err(|_| Error::Decrypt)
     }
 
     /// Generates a new key for the egress symmetric cipher according to Section 4.2


### PR DESCRIPTION
Maybe it's better to add new methods? But this is very useful especially when using it with a transport like quic, where the crypto frames contain the handshake and then the whole packet is encrypted using the plain text packet header as associated data.