### PR TITLE
Update dead docs link for forming NoiseParams strings

### DIFF
--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -125,7 +125,7 @@ impl FromStr for KemChoice {
 
 /// The set of choices (as specified in the Noise spec) that constitute a full protocol definition.
 ///
-/// See: [Chapter 11: Protocol Names](http://noiseprotocol.org/noise.html#protocol-names).
+/// See: [Chapter 8: Protocol names and modifiers](https://noiseprotocol.org/noise.html#protocol-names-and-modifiers).
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The noise protocol spec has moved around since this doc comment was written and the link no longer takes you to the correct heading (or any heading at all). This updates the `NoiseParams` docs to link to the new location.