### PR TITLE
Add StatelessTransportState::initiator_key and responder_key

### DIFF
--- a/src/cipherstate.rs
+++ b/src/cipherstate.rs
@@ -167,6 +167,10 @@ impl StatelessCipherState {
     pub fn rekey_manually(&mut self, key: &[u8]) {
         self.cipher.set(key);
     }
+
+    pub fn key(&self) -> &[u8] {
+        self.cipher.get()
+    }
 }
 
 impl From<CipherState> for StatelessCipherState {

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -195,6 +195,10 @@ impl Cipher for CipherAesGcm {
         copy_slices!(key, &mut self.key)
     }
 
+    fn get(&self) -> &[u8] {
+        &self.key
+    }
+
     fn encrypt(&self, nonce: u64, authtext: &[u8], plaintext: &[u8], out: &mut [u8]) -> usize {
         let aead = aes_gcm::Aes256Gcm::new(&self.key.into());
 
@@ -246,6 +250,10 @@ impl Cipher for CipherChaChaPoly {
 
     fn set(&mut self, key: &[u8]) {
         copy_slices!(key, &mut self.key);
+    }
+
+    fn get(&self) -> &[u8] {
+        &self.key
     }
 
     fn encrypt(&self, nonce: u64, authtext: &[u8], plaintext: &[u8], out: &mut [u8]) -> usize {

--- a/src/stateless_transportstate.rs
+++ b/src/stateless_transportstate.rs
@@ -140,6 +140,24 @@ impl StatelessTransportState {
     pub fn is_initiator(&self) -> bool {
         self.initiator
     }
+
+    /// Gets the initiator's current symmetric key.
+    ///
+    /// This can be passed to `rekey_initiator_manually` to restore the state to
+    /// before a reykeying, in case you need to work with messages that have come in
+    /// before then.
+    pub fn initiator_key(&self) -> &[u8] {
+        self.cipherstates.0.key()
+    }
+
+    /// Gets the responder's current symmetric key.
+    ///
+    /// This can be passed to `rekey_responder_manually` to restore the state to
+    /// before a reykeying, in case you need to work with messages that have come in
+    /// before then.
+    pub fn responder_key(&self) -> &[u8] {
+        self.cipherstates.1.key()
+    }
 }
 
 impl fmt::Debug for StatelessTransportState {

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,6 +44,9 @@ pub trait Cipher: Send + Sync {
     /// Set the key
     fn set(&mut self, key: &[u8]);
 
+    /// Get the key
+    fn get(&self) -> &[u8];
+
     /// Encrypt (with associated data) a given plaintext.
     fn encrypt(&self, nonce: u64, authtext: &[u8], plaintext: &[u8], out: &mut [u8]) -> usize;
 


### PR DESCRIPTION
Allows for saving and restoring of keys across re-keys.

This can be useful, for example, if you are working with UDP and
need to decrypt a packet that arrived after a rekey but was sent
before the rekey.