### PR TITLE
Pin `curve25519-dalek` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ aes-gcm = { version = "0.9", optional = true }
 chacha20poly1305 = { version = "0.9", optional = true }
 blake2 = { version = "0.10", optional = true }
 sha2 = { version = "0.10", optional = true }
-curve25519-dalek = { version = "4.0.0-pre.2", optional = true }
+curve25519-dalek = { version = "=4.0.0-pre.2", optional = true }
 
 pqcrypto-kyber = { version = "0.7", optional = true }
 pqcrypto-traits = { version = "0.3", optional = true }


### PR DESCRIPTION
Pre-releases are compared lexicographically. Pre-releases are also allowed to make breaking changes. Depending on a pre-release without pinning is likely to cause breakages downstream.

Pin the dependency until this issue is resolved.

Fixes https://github.com/mcginty/snow/issues/146.