### PR TITLE
Bump `curve25519-dalek` to v4.0.0-rc.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 [features]
 default = ["default-resolver"]
 default-resolver = ["aes-gcm", "chacha20poly1305", "blake2", "sha2", "curve25519-dalek"]
-nightly = ["blake2/simd_opt", "curve25519-dalek/nightly", "subtle/nightly"]
+nightly = ["blake2/simd_opt", "subtle/nightly"]
 ring-resolver = ["ring"]
 ring-accelerated = ["ring-resolver", "default-resolver"]
 libsodium-resolver = ["sodiumoxide", "byteorder"]
@@ -45,7 +45,7 @@ aes-gcm = { version = "0.9", optional = true }
 chacha20poly1305 = { version = "0.9", optional = true }
 blake2 = { version = "0.10", optional = true }
 sha2 = { version = "0.10", optional = true }
-curve25519-dalek = { version = "4.0.0-pre.2", optional = true }
+curve25519-dalek = { version = "=4.0.0-rc.0", optional = true }
 
 pqcrypto-kyber = { version = "0.7", optional = true }
 pqcrypto-traits = { version = "0.3", optional = true }

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -5,7 +5,7 @@ use chacha20poly1305::{
     aead::{AeadInPlace, NewAead},
     ChaCha20Poly1305,
 };
-use curve25519_dalek::{constants::ED25519_BASEPOINT_TABLE, scalar::Scalar, montgomery::MontgomeryPoint};
+use curve25519_dalek::{edwards::EdwardsPoint, montgomery::MontgomeryPoint, scalar::Scalar};
 #[cfg(feature = "pqclean_kyber1024")]
 use pqcrypto_kyber::kyber1024;
 #[cfg(feature = "pqclean_kyber1024")]
@@ -128,8 +128,9 @@ impl Random for OsRng {}
 
 impl Dh25519 {
     fn derive_pubkey(&mut self) {
-        // https://github.com/dalek-cryptography/x25519-dalek/blob/1c39ff92e0dfc0b24aa02d694f26f3b9539322a5/src/x25519.rs#L150
-        let point = (&ED25519_BASEPOINT_TABLE * &self.privkey).to_montgomery();
+        // TODO: use `MontgomeryPoint::mul_base` in final v4 release of curve25519-dalek
+        // See dalek-cryptography/curve25519-dalek#503
+        let point = EdwardsPoint::mul_base(&self.privkey).to_montgomery();
         self.pubkey = point.to_bytes();
     }
 }


### PR DESCRIPTION
This also makes use of `EdwardsPoint::mul_base` which abstracts over implementation details like basepoint tables.

It also adds a TODO to use a forthcoming `MontgomeryPoint::mul_base` API: dalek-cryptography/curve25519-dalek#503