### PR TITLE
Update various links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "snow"
 description = "A pure-rust implementation of the Noise Protocol Framework"
-homepage = "https://snow.rs"
-documentation = "https://snow.rs/doc/snow"
+homepage = "https://github.com/mcginty/snow"
+documentation = "https://docs.rs/snow/"
 repository = "https://github.com/mcginty/snow"
 version = "0.9.0"
 authors = ["Jake McGinty <me@jake.su>", "trevp"]

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,6 +1,6 @@
                               Apache License
                         Version 2.0, January 2004
-                     http://www.apache.org/licenses/
+                     https://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ specification.
 
 Licensed under either of:
 
-- [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
-- [MIT license](http://opensource.org/licenses/MIT)
+- [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](https://opensource.org/license/mit/)
 
 at your option.
 

--- a/src/handshakestate.rs
+++ b/src/handshakestate.rs
@@ -25,7 +25,7 @@ use std::{
 /// **Note:** you are probably looking for [`Builder`](struct.Builder.html) to
 /// get started.
 ///
-/// See: [http://noiseprotocol.org/noise.html#the-handshakestate-object](http://noiseprotocol.org/noise.html#the-handshakestate-object)
+/// See: https://noiseprotocol.org/noise.html#the-handshakestate-object
 pub struct HandshakeState {
     pub(crate) rng:              Box<dyn Random>,
     pub(crate) symmetricstate:   SymmetricState,
@@ -177,7 +177,7 @@ impl HandshakeState {
 
     /// This method will return `true` if the *previous* write payload was encrypted.
     ///
-    /// See [Payload Security Properties](http://noiseprotocol.org/noise.html#payload-security-properties)
+    /// See [Payload Security Properties](https://noiseprotocol.org/noise.html#payload-security-properties)
     /// for more information on the specific properties of your chosen handshake pattern.
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! The `snow` crate is a straightforward, Hard To Fuck Up™ Noise Protocol implementation.
 //!
-//! Read the [Noise Protocol Framework Spec](http://noiseprotocol.org/noise.html) for more
+//! Read the [Noise Protocol Framework Spec](https://noiseprotocol.org/noise.html) for more
 //! information.
 //!
 //! The typical usage flow is to use [`Builder`] to construct a [`HandshakeState`], where you

--- a/src/params/patterns.rs
+++ b/src/params/patterns.rs
@@ -29,7 +29,7 @@ macro_rules! pattern_enum {
         $($variant:ident),* $(,)*
     }) => {
         /// One of the patterns as defined in the
-        /// [Handshake Pattern](http://noiseprotocol.org/noise.html#handshake-patterns)
+        /// [Handshake Pattern](https://noiseprotocol.org/noise.html#handshake-patterns)
         /// section.
         #[allow(missing_docs)]
         #[derive(Copy, Clone, PartialEq, Debug)]
@@ -71,7 +71,7 @@ macro_rules! pattern_enum {
 
 /// The tokens which describe patterns involving DH calculations.
 ///
-/// See: http://noiseprotocol.org/noise.html#handshake-patterns
+/// See: https://noiseprotocol.org/noise.html#handshake-patterns
 #[allow(missing_docs)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub(crate) enum DhToken {
@@ -83,7 +83,7 @@ pub(crate) enum DhToken {
 
 /// The tokens which describe message patterns.
 ///
-/// See: http://noiseprotocol.org/noise.html#handshake-patterns
+/// See: https://noiseprotocol.org/noise.html#handshake-patterns
 #[allow(missing_docs)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub(crate) enum Token {
@@ -273,7 +273,7 @@ pub(crate) type MessagePatterns = Vec<Vec<Token>>;
 
 /// The defined token patterns for a given handshake.
 ///
-/// See: http://noiseprotocol.org/noise.html#handshake-patterns
+/// See: https://noiseprotocol.org/noise.html#handshake-patterns
 #[derive(Debug)]
 pub(crate) struct HandshakeTokens {
     pub premsg_pattern_i: PremessagePatterns,

--- a/src/params/patterns.rs
+++ b/src/params/patterns.rs
@@ -125,7 +125,7 @@ pattern_enum! {
 impl HandshakePattern {
     /// If the protocol is one-way only
     ///
-    /// See: http://noiseprotocol.org/noise.html#one-way-patterns
+    /// See: https://noiseprotocol.org/noise.html#one-way-handshake-patterns
     pub fn is_oneway(self) -> bool {
         matches!(self, N | X | K)
     }

--- a/src/stateless_transportstate.rs
+++ b/src/stateless_transportstate.rs
@@ -12,7 +12,7 @@ use std::{convert::TryFrom, fmt};
 /// `CipherState`s (for sending and receiving) that were spawned from the `SymmetricState`'s
 /// `Split()` method, called after a handshake has been finished.
 ///
-/// See: http://noiseprotocol.org/noise.html#the-handshakestate-object
+/// See: https://noiseprotocol.org/noise.html#the-handshakestate-object
 pub struct StatelessTransportState {
     cipherstates: StatelessCipherStates,
     pattern:      HandshakePattern,

--- a/src/transportstate.rs
+++ b/src/transportstate.rs
@@ -12,7 +12,7 @@ use std::{convert::TryFrom, fmt};
 /// `CipherState`s (for sending and receiving) that were spawned from the `SymmetricState`'s
 /// `Split()` method, called after a handshake has been finished.
 ///
-/// Also see: [the relevant Noise spec section](http://noiseprotocol.org/noise.html#the-handshakestate-object).
+/// Also see: [the relevant Noise spec section](https://noiseprotocol.org/noise.html#the-handshakestate-object).
 pub struct TransportState {
     cipherstates: CipherStates,
     pattern:      HandshakePattern,


### PR DESCRIPTION
I noticed (as mentioned in #124) that snow.rs is currently parked and thought it'd be helpful to remove that reference from the official documentation. I also updated various other links to use https and fixed an anchor ref that no longer works. 

There's another broken link that's already been fixed in master but the Rust docs haven't been updated, so it'd be great to get a 0.9.2 published with that and these updates when you have a chance. ❤️ 