### PR TITLE
Fix nonce incrementing in stateful transport to match the specification

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -60,8 +60,7 @@ pub trait Cipher: Send + Sync {
     /// implementation guaranteed to be secure for all ciphers.
     fn rekey(&mut self) {
         let mut ciphertext = [0; CIPHERKEYLEN + TAGLEN];
-        let ciphertext_len =
-            self.encrypt(u64::max_value(), &[], &[0; CIPHERKEYLEN], &mut ciphertext);
+        let ciphertext_len = self.encrypt(u64::MAX, &[], &[0; CIPHERKEYLEN], &mut ciphertext);
         assert_eq!(ciphertext_len, ciphertext.len());
         self.set(&ciphertext[..CIPHERKEYLEN]);
     }


### PR DESCRIPTION
This PR fixes https://github.com/mcginty/snow/issues/150 by correcting the stateful encrypt/decrypt functions to never use the reserved value of `u64::MAX`, which additionally guarantees a lack of wraparound issues.

In addition, a unit test was added to ensure this behavior does not regress by mistake.

Fixes https://github.com/mcginty/snow/issues/150