### PR TITLE
s/Ed448/Curve448/

### DIFF
--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -36,7 +36,7 @@ impl FromStr for BaseChoice {
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub enum DHChoice {
     Curve25519,
-    Ed448,
+    Curve448,
 }
 
 impl FromStr for DHChoice {
@@ -46,7 +46,7 @@ impl FromStr for DHChoice {
         use self::DHChoice::*;
         match s {
             "25519" => Ok(Curve25519),
-            "448" => Ok(Ed448),
+            "448" => Ok(Curve448),
             _ => Err(PatternProblem::UnsupportedDhType.into()),
         }
     }

--- a/tests/vectors.rs
+++ b/tests/vectors.rs
@@ -24,7 +24,7 @@ use std::{
 #[derive(Clone)]
 struct HexBytes {
     original: String,
-    payload:  Vec<u8>,
+    payload: Vec<u8>,
 }
 
 impl From<Vec<u8>> for HexBytes {
@@ -85,7 +85,7 @@ impl Serialize for HexBytes {
 
 #[derive(Serialize, Deserialize)]
 struct TestMessage {
-    payload:    HexBytes,
+    payload: HexBytes,
     ciphertext: HexBytes,
 }
 
@@ -128,13 +128,13 @@ struct TestVector {
     #[serde(skip_serializing_if = "Option::is_none")]
     init_remote_static: Option<HexBytes>,
 
-    resp_prologue:      HexBytes,
+    resp_prologue: HexBytes,
     #[serde(skip_serializing_if = "Option::is_none")]
-    resp_psks:          Option<Vec<HexBytes>>,
+    resp_psks: Option<Vec<HexBytes>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    resp_static:        Option<HexBytes>,
+    resp_static: Option<HexBytes>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    resp_ephemeral:     Option<HexBytes>,
+    resp_ephemeral: Option<HexBytes>,
     #[serde(skip_serializing_if = "Option::is_none")]
     resp_remote_static: Option<HexBytes>,
 
@@ -264,7 +264,7 @@ fn test_vectors_from_json(json: &str) {
     for vector in test_vectors.vectors {
         let params: NoiseParams = vector.protocol_name.parse().unwrap();
 
-        if params.dh == DHChoice::Ed448 {
+        if params.dh == DHChoice::Curve448 {
             ignored += 1;
             continue;
         }
@@ -378,7 +378,7 @@ fn generate_vector(params: NoiseParams) -> TestVector {
         let payload = random_vec(32);
         let len = init.write_message(&payload, &mut ibuf).unwrap();
         messages.push(TestMessage {
-            payload:    payload.clone().into(),
+            payload: payload.clone().into(),
             ciphertext: ibuf[..len].to_vec().into(),
         });
         let _ = resp.read_message(&ibuf[..len], &mut obuf).unwrap();
@@ -390,7 +390,7 @@ fn generate_vector(params: NoiseParams) -> TestVector {
         let payload = random_vec(32);
         let len = resp.write_message(&payload, &mut ibuf).unwrap();
         messages.push(TestMessage {
-            payload:    payload.clone().into(),
+            payload: payload.clone().into(),
             ciphertext: ibuf[..len].to_vec().into(),
         });
         let _ = init.read_message(&ibuf[..len], &mut obuf).unwrap();


### PR DESCRIPTION
Ed448 is a Schnorr signature algorithm over the edwards448 curve, which is birationally equivalent to, but not the same curve as, curve448, a Montgomery curve. Curve448 is used to perform Diffie-Hellman, similar to the smaller curve25519. This just appears to be a mis-name in `DHChoice`
