### PR TITLE
Bump curve25519-dalek from 4.0.0-rc.2 to 4.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ aes-gcm = { version = "0.9", optional = true }
 chacha20poly1305 = { version = "0.9", optional = true }
 blake2 = { version = "0.10", optional = true }
 sha2 = { version = "0.10", optional = true }
-curve25519-dalek = { version = "=4.0.0-rc.2", optional = true }
+curve25519-dalek = { version = "4.0.0", features = ["legacy_compatibility"], optional = true }
 
 pqcrypto-kyber = { version = "0.7", optional = true }
 pqcrypto-traits = { version = "0.3", optional = true }

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -140,6 +140,9 @@ fn clamp_scalar(mut scalar: [u8; 32]) -> Scalar {
     scalar[31] &= 127;
     scalar[31] |= 64;
 
+    // The above bit operations ensure that the integer represented by
+    // `scalar_bytes` is less than 2***255-19 as required by this function.
+    #[allow(deprecated)]
     Scalar::from_bits(scalar)
 }
 


### PR DESCRIPTION
This removes the fixed dependency version which makes it easier to merge this dependency with other crates.

Add a comment why using the deprecated method is okay.