### PR TITLE
Simplify example code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ sodiumoxide = { version = "0.2", optional = true }
 byteorder = { version = "1.4", optional = true }
 
 [dev-dependencies]
-clap = "4.0"
 criterion = "0.5"
 serde = "1.0"
 serde_json = "1.0"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -10,8 +10,6 @@
 //! as `cargo run --example simple` to see the magic happen.
 
 use lazy_static::lazy_static;
-
-use clap::{arg, Command};
 use snow::{params::NoiseParams, Builder};
 use std::{
     io::{self, Read, Write},
@@ -25,9 +23,10 @@ lazy_static! {
 
 #[cfg(any(feature = "default-resolver", feature = "ring-accelerated"))]
 fn main() {
-    let matches = Command::new("simple").arg(arg!(-s --server "Server mode")).get_matches();
+    let server_mode =
+        std::env::args().next_back().map(|arg| arg == "-s" || arg == "--server").unwrap_or(true);
 
-    if matches.contains_id("server") {
+    if server_mode {
         run_server();
     } else {
         run_client();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -40,7 +40,7 @@ fn run_server() {
     let mut buf = vec![0u8; 65535];
 
     // Initialize our responder using a builder.
-    let builder: Builder<'_> = Builder::new(PARAMS.clone());
+    let builder = Builder::new(PARAMS.clone());
     let static_key = builder.generate_keypair().unwrap().private;
     let mut noise =
         builder.local_private_key(&static_key).psk(3, SECRET).build_responder().unwrap();
@@ -53,7 +53,7 @@ fn run_server() {
     noise.read_message(&recv(&mut stream).unwrap(), &mut buf).unwrap();
 
     // -> e, ee, s, es
-    let len = noise.write_message(&[0u8; 0], &mut buf).unwrap();
+    let len = noise.write_message(&[], &mut buf).unwrap();
     send(&mut stream, &buf[..len]);
 
     // <- s, se
@@ -74,7 +74,7 @@ fn run_client() {
     let mut buf = vec![0u8; 65535];
 
     // Initialize our initiator using a builder.
-    let builder: Builder<'_> = Builder::new(PARAMS.clone());
+    let builder = Builder::new(PARAMS.clone());
     let static_key = builder.generate_keypair().unwrap().private;
     let mut noise =
         builder.local_private_key(&static_key).psk(3, SECRET).build_initiator().unwrap();
@@ -109,7 +109,7 @@ fn run_client() {
 fn recv(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
     let mut msg_len_buf = [0u8; 2];
     stream.read_exact(&mut msg_len_buf)?;
-    let msg_len = ((msg_len_buf[0] as usize) << 8) + (msg_len_buf[1] as usize);
+    let msg_len = usize::from(u16::from_be_bytes(msg_len_buf));
     let mut msg = vec![0u8; msg_len];
     stream.read_exact(&mut msg[..])?;
     Ok(msg)
@@ -117,8 +117,8 @@ fn recv(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
 
 /// Hyper-basic stream transport sender. 16-bit BE size followed by payload.
 fn send(stream: &mut TcpStream, buf: &[u8]) {
-    let msg_len_buf = [(buf.len() >> 8) as u8, (buf.len() & 0xff) as u8];
-    stream.write_all(&msg_len_buf).unwrap();
+    let len = u16::try_from(buf.len()).expect("message too large");
+    stream.write_all(&len.to_be_bytes()).unwrap();
     stream.write_all(buf).unwrap();
 }
 


### PR DESCRIPTION
Slightly tidies up the example to use more modern Rust, less type specifications, and then drops `clap` as a direct dependency. The expected behavior from the example's CLI meant a whole CLI argument library was very over the top. Also its been broken since the update to `clap 0.4`. Running `cargo run --example simple` would attempt to rebind the server instead of connecting as a client. The replaced args parsing handles it right again:

<img width="1286" alt="Screenshot 2023-12-19 at 12 59 36 PM" src="https://github.com/mcginty/snow/assets/20936452/e1db4e82-3092-4afb-bb2e-a83aa69a78e9">

Closes #178 
