### PR TITLE
Update clap for 0.9 releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,7 @@ sodiumoxide = { version = "0.2", optional = true }
 byteorder = { version = "1.4", optional = true }
 
 [dev-dependencies]
-clap = "3"
-criterion = "0.3"
+criterion = "0.5"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -10,8 +10,6 @@
 //! as `cargo run --example simple` to see the magic happen.
 
 use lazy_static::lazy_static;
-
-use clap::{arg, App};
 use snow::{params::NoiseParams, Builder};
 use std::{
     io::{self, Read, Write},
@@ -25,9 +23,10 @@ lazy_static! {
 
 #[cfg(any(feature = "default-resolver", feature = "ring-accelerated"))]
 fn main() {
-    let matches = App::new("simple").arg(arg!("-s --server 'Server mode'")).get_matches();
+    let server_mode =
+        std::env::args().next_back().map(|arg| arg == "-s" || arg == "--server").unwrap_or(true);
 
-    if matches.is_present("server") {
+    if server_mode {
         run_server();
     } else {
         run_client();


### PR DESCRIPTION
This backports the criterion 0.5 update from `main` to the released version and also cherry-picks half of https://github.com/mcginty/snow/pull/175 into here as well to remove the direct `clap` dependency.

Closes https://github.com/mcginty/snow/issues/174