### PR TITLE
Add support for NIST P-256 curve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ aes-gcm = { version = "0.10", optional = true }
 chacha20poly1305 = { version = "0.10", optional = true }
 blake2 = { version = "0.10", optional = true }
 sha2 = { version = "0.10", optional = true }
-curve25519-dalek = { version = "4", optional = true }
+curve25519-dalek = { version = "4.1.3", optional = true }
 
 pqcrypto-kyber = { version = "0.8", optional = true }
 pqcrypto-traits = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 # and -accelerated suffix means that this resolver will be the default used by the Builder.
 [features]
 default = ["default-resolver"]
-default-resolver = ["aes-gcm", "chacha20poly1305", "blake2", "sha2", "curve25519-dalek"]
+default-resolver = ["aes-gcm", "chacha20poly1305", "blake2", "sha2", "curve25519-dalek", "p256"]
 nightly = ["blake2/simd_opt", "subtle/nightly"]
 ring-resolver = ["ring"]
 ring-accelerated = ["ring-resolver", "default-resolver"]
@@ -46,6 +46,7 @@ chacha20poly1305 = { version = "0.10", optional = true }
 blake2 = { version = "0.10", optional = true }
 sha2 = { version = "0.10", optional = true }
 curve25519-dalek = { version = "4.1.3", optional = true }
+p256 = { version = "0.13.2", features = ["ecdh"], optional = true }
 
 pqcrypto-kyber = { version = "0.8", optional = true }
 pqcrypto-traits = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 # and -accelerated suffix means that this resolver will be the default used by the Builder.
 [features]
 default = ["default-resolver"]
-default-resolver = ["aes-gcm", "chacha20poly1305", "blake2", "sha2", "curve25519-dalek", "p256"]
+default-resolver = ["aes-gcm", "chacha20poly1305", "blake2", "sha2", "curve25519-dalek"]
 nightly = ["blake2/simd_opt", "subtle/nightly"]
 ring-resolver = ["ring"]
 ring-accelerated = ["ring-resolver", "default-resolver"]
@@ -27,6 +27,7 @@ vector-tests = []
 hfs = []
 pqclean_kyber1024 = ["pqcrypto-kyber", "pqcrypto-traits", "hfs", "default-resolver"]
 xchachapoly = ["chacha20poly1305", "default-resolver"]
+p256 = ["dep:p256", "default-resolver"]
 risky-raw-split = []
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ crypto implementations when available.
 |     CSPRNG |    ✔    |  ✔   |
 |      25519 |    ✔    |  ✔   |
 |        448 |         |      |
+|      P-256 |    ✔    |      |
 |     AESGCM |    ✔    |  ✔   |
 | ChaChaPoly |    ✔    |  ✔   |
 |     SHA256 |    ✔    |  ✔   |

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,7 +4,7 @@ pub const TAGLEN: usize = 16;
 
 pub const MAXHASHLEN: usize = 64;
 pub const MAXBLOCKLEN: usize = 128;
-pub const MAXDHLEN: usize = 56;
+pub const MAXDHLEN: usize = 65;
 pub const MAXMSGLEN: usize = 65535;
 
 #[cfg(feature = "hfs")]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,8 +4,15 @@ pub const TAGLEN: usize = 16;
 
 pub const MAXHASHLEN: usize = 64;
 pub const MAXBLOCKLEN: usize = 128;
-pub const MAXDHLEN: usize = 65;
 pub const MAXMSGLEN: usize = 65535;
+
+// P-256 uncompressed SEC-1 encodings are 65 bytes long, larger
+// than the `MAXDHLEN` in the official Noise spec.
+#[cfg(feature = "p256")]
+pub const MAXDHLEN: usize = 65;
+// Curve448 keys are the largest in the official Noise spec.
+#[cfg(not(feature = "p256"))]
+pub const MAXDHLEN: usize = 56;
 
 #[cfg(feature = "hfs")]
 pub const MAXKEMPUBLEN: usize = 4096;

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -41,6 +41,7 @@ pub enum DHChoice {
     Curve25519,
     /// The Curve448 elliptic curve.
     Curve448,
+    #[cfg(feature = "p256")]
     /// The P-256 elliptic curve.
     P256,
 }
@@ -53,6 +54,7 @@ impl FromStr for DHChoice {
         match s {
             "25519" => Ok(Curve25519),
             "448" => Ok(Curve448),
+            #[cfg(feature = "p256")]
             "P256" => Ok(P256),
             _ => Err(PatternProblem::UnsupportedDhType.into()),
         }
@@ -274,6 +276,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "p256")]
     fn test_p256() {
         let p: NoiseParams = "Noise_XX_P256_AESGCM_SHA256".parse().unwrap();
         assert_eq!(p.dh, DHChoice::P256);

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -37,10 +37,12 @@ impl FromStr for BaseChoice {
 /// Which Diffie-Hellman primitive to use. One of `25519` or `448`, per the spec.
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub enum DHChoice {
-    /// The Curve25519 ellpitic curve.
+    /// The Curve25519 elliptic curve.
     Curve25519,
     /// The Curve448 elliptic curve.
     Curve448,
+    /// The P-256 elliptic curve.
+    P256,
 }
 
 impl FromStr for DHChoice {
@@ -51,6 +53,7 @@ impl FromStr for DHChoice {
         match s {
             "25519" => Ok(Curve25519),
             "448" => Ok(Curve448),
+            "P256" => Ok(P256),
             _ => Err(PatternProblem::UnsupportedDhType.into()),
         }
     }
@@ -268,6 +271,12 @@ mod tests {
     fn test_basic() {
         let p: NoiseParams = "Noise_XX_25519_AESGCM_SHA256".parse().unwrap();
         assert!(p.handshake.modifiers.list.is_empty());
+    }
+
+    #[test]
+    fn test_p256() {
+        let p: NoiseParams = "Noise_XX_P256_AESGCM_SHA256".parse().unwrap();
+        assert_eq!(p.dh, DHChoice::P256);
     }
 
     #[test]

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -3,11 +3,8 @@ use blake2::{Blake2b, Blake2b512, Blake2s, Blake2s256};
 use chacha20poly1305::XChaCha20Poly1305;
 use chacha20poly1305::{aead::AeadInPlace, ChaCha20Poly1305, KeyInit};
 use curve25519_dalek::montgomery::MontgomeryPoint;
-use p256::{
-    self,
-    elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
-    CompressedPoint, EncodedPoint, SecretKey,
-};
+#[cfg(feature = "p256")]
+use p256::{self, elliptic_curve::sec1::ToEncodedPoint, EncodedPoint};
 #[cfg(feature = "pqclean_kyber1024")]
 use pqcrypto_kyber::kyber1024;
 #[cfg(feature = "pqclean_kyber1024")]
@@ -43,8 +40,8 @@ impl CryptoResolver for DefaultResolver {
         match *choice {
             DHChoice::Curve25519 => Some(Box::<Dh25519>::default()),
             DHChoice::Curve448 => None,
+            #[cfg(feature = "p256")]
             DHChoice::P256 => Some(Box::<P256>::default()),
-            _ => None,
         }
     }
 
@@ -82,6 +79,7 @@ struct Dh25519 {
 }
 
 /// Wraps p256
+#[cfg(feature = "p256")]
 #[derive(Default)]
 struct P256 {
     privkey: [u8; 32],
@@ -189,6 +187,7 @@ impl Dh for Dh25519 {
     }
 }
 
+#[cfg(feature = "p256")]
 impl P256 {
     fn derive_pubkey(&mut self) {
         let secret_key = p256::SecretKey::from_bytes(&self.privkey.into()).unwrap();
@@ -198,6 +197,7 @@ impl P256 {
     }
 }
 
+#[cfg(feature = "p256")]
 impl Dh for P256 {
     fn name(&self) -> &'static str {
         "P256"

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -689,21 +689,24 @@ mod tests {
     #[test]
     #[cfg(feature = "p256")]
     fn test_p256() {
+        // Test vector from RFC 5903, section 8.1
         let mut keypair = P256::default();
         let scalar =
-            Vec::<u8>::from_hex("58c77a30bb0fa177286346d18f59678ac1b8d3637ee65f1bd88a8f52e49ef189")
+            Vec::<u8>::from_hex("C88F01F510D9AC3F70A292DAA2316DE544E9AAB8AFE84049C62A9C57862D1433")
                 .unwrap();
         keypair.set(&scalar);
+        // Public key is prefixed with 0x04, to indicate uncompressed form, as per SEC1 encoding
         let public = Vec::<u8>::from_hex(
-            "042009fddefeed3b342696b11683b423db8ede2ef5cd66af9b7db2772f7deaf3d\
-                                 f1a69a4648d990ae2a4e5928f156f32e15fa08ba4465df8cb17838dc2afb719d2",
+            "04\
+                D12DFB5289C8D4F81208B70270398C342296970A0BCCB74C736FC7554494BF63\
+                56FBF3CA366CC23E8157854C13C58D6AAC23F046ADA30F8353E74F33039872AB",
         )
         .unwrap();
         let mut output = [0u8; 32];
         keypair.dh(&public, &mut output).unwrap();
         assert_eq!(
             hex::encode(output),
-            "07505b308650d07e6ead11dd36bbf6f24bf99fc6479649fadd3939faa33ddeb3"
+            "D6840F6B42F6EDAFD13116E0E12565202FEF8E9ECE7DCE03812464D04B9442DE".to_lowercase()
         );
     }
 

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -683,6 +683,27 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "p256")]
+    fn test_p256() {
+        let mut keypair = P256::default();
+        let scalar =
+            Vec::<u8>::from_hex("58c77a30bb0fa177286346d18f59678ac1b8d3637ee65f1bd88a8f52e49ef189")
+                .unwrap();
+        keypair.set(&scalar);
+        let public = Vec::<u8>::from_hex(
+            "042009fddefeed3b342696b11683b423db8ede2ef5cd66af9b7db2772f7deaf3d\
+                                 f1a69a4648d990ae2a4e5928f156f32e15fa08ba4465df8cb17838dc2afb719d2",
+        )
+        .unwrap();
+        let mut output = [0u8; 32];
+        keypair.dh(&public, &mut output).unwrap();
+        assert_eq!(
+            hex::encode(output),
+            "07505b308650d07e6ead11dd36bbf6f24bf99fc6479649fadd3939faa33ddeb3"
+        );
+    }
+
+    #[test]
     fn test_aesgcm() {
         // AES256-GCM tests - gcm-spec.pdf
         // Test Case 13

--- a/src/resolvers/default.rs
+++ b/src/resolvers/default.rs
@@ -211,6 +211,10 @@ impl Dh for P256 {
         32 // Scalar
     }
 
+    fn dh_len(&self) -> usize {
+        32
+    }
+
     fn set(&mut self, privkey: &[u8]) {
         let mut bytes = [0u8; 32];
         copy_slices!(privkey, bytes);

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,6 +37,11 @@ pub trait Dh: Send + Sync {
     /// # Errors
     /// Returns `Error::Dh` in the event that the Diffie-Hellman failed.
     fn dh(&self, pubkey: &[u8], out: &mut [u8]) -> Result<(), Error>;
+
+    /// The lenght in bytes of of the DH key exchange. Defaults to the public key.
+    fn dh_len(&self) -> usize {
+        self.pub_len()
+    }
 }
 
 /// Cipher operations


### PR DESCRIPTION
## Changes

* Adds support for NIST P-256, aka secp256r1, using the [p256 crate from RustCrypto](https://github.com/RustCrypto/elliptic-curves/tree/master/p256). This is a pure-Rust implementation.
* As per feedback in previous abandoned PR https://github.com/mcginty/snow/pull/38#issuecomment-435416354, the code is feature gated, as this is a non-standard curve.
* Includes PR #181 which updates curve25519-dalek, which unbreaks the build for me.

## Motivation

This curve is used for the Noise handshake in [CTAP2 Hybrid Transport](https://fidoalliance.org/specs/fido-v2.2-rd-20230321/fido-client-to-authenticator-protocol-v2.2-rd-20230321.html#hybrid-qr-initiated). This is the protocol used for browsers to access FIDO2 credentials (aka Passkeys) on roaming authenticators connected over the internet, such as phones running Android and iOS. 

I'm using snow in my implementation of CTAP2, aimed at bringing Passkeys to the Linux desktop, see [xdg-credentials-portal](https://github.com/AlfioEmanueleFresta/xdg-credentials-portal).

## Tests

All commands below succeed:

```
$ cargo build --all-targets
$ cargo build --all-targets --features p256
$ cargo test --all-targets
$ cargo test --all-targets --features p256
```

