### PR TITLE
Remove direct dependency on rand and rand_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ xchachapoly = ["use-xchacha20poly1305"]
 
 # Enable std features on dependencies if possible.
 std = [
-    "rand_core/std",
+    "getrandom/std",
     "subtle/std",
     "ring/std",
     "blake2/std",
@@ -73,8 +73,7 @@ harness = false
 travis-ci = { repository = "mcginty/snow", branch = "master" }
 
 [dependencies]
-# TODO: Waiting on https://github.com/RustCrypto/traits/issues/1642
-rand_core = { version = "0.9", default-features = false, features = ["os_rng"] }
+getrandom = { version = "0.3" }
 subtle = { version = "2.4", default-features = false }
 
 # default crypto provider
@@ -101,8 +100,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 hex = "0.4"
 x25519-dalek = "2.0"
-# TODO: Waiting on https://github.com/RustCrypto/traits/issues/1642
-rand = "0.9"
+rand_core = { version = "0.9", default-features = false }
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/src/resolvers/ring.rs
+++ b/src/resolvers/ring.rs
@@ -45,6 +45,8 @@ impl CryptoResolver for RingResolver {
     }
 }
 
+// NB: Intentionally private so RNG details aren't leaked into
+// the public API.
 struct RingRng {
     rng: SystemRandom,
 }

--- a/tests/vectors.rs
+++ b/tests/vectors.rs
@@ -4,7 +4,6 @@
 extern crate serde_derive;
 
 use hex::FromHex;
-use rand::RngCore;
 use serde::{
     de::{self, Deserialize, Deserializer, Unexpected, Visitor},
     ser::{Serialize, Serializer},
@@ -306,15 +305,13 @@ fn test_vectors_from_json(json: &str) {
 
 fn random_slice<const N: usize>() -> [u8; N] {
     let mut v = [0_u8; N];
-    let mut rng = rand::rng();
-    rng.fill_bytes(&mut v);
+    getrandom::fill(&mut v).unwrap();
     v
 }
 
 fn random_vec(size: usize) -> Vec<u8> {
     let mut v = vec![0_u8; size];
-    let mut rng = rand::rng();
-    rng.fill_bytes(&mut v);
+    getrandom::fill(&mut v).unwrap();
     v
 }
 


### PR DESCRIPTION
This PR proposes dropping `snow`'s direct dependency on `rand_core` in the normal set of dependencies (and `rand` in general). My reasoning here is that Snow isn't using `rand_core` for anything except an interface to the OS's random number generator, which the more version-stable `getrandom` crate can handle with less abstraction. 

This way, ideally, there's less dependency churn and bitrot in lockfiles of `snow` consumers and these versions instead naturally stay in sync with what the current version of the `RustCrypto` ecosystem is using.

Additionally, `OsRng` is no longer exposed in `snow`'s public API which reduces semver hazards (this could be done independently as well):
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/69f0bde8-8fe2-4227-b067-a6c67e96f901" />
