### PR TITLE
Use weak Cargo dependency features for std feature list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ pqclean_kyber1024 = ["use-pqcrypto-kyber1024"]
 xchachapoly = ["use-xchacha20poly1305"]
 
 # Enable std features on dependencies if possible.
-std = ["getrandom/std", "subtle/std", "ring/std", "blake2/std", "sha2/std"]
+std = ["getrandom?/std", "subtle/std", "ring?/std", "blake2?/std", "sha2?/std"]
 
 # Crypto primitives for default-resolver.
 use-curve25519 = ["curve25519-dalek", "default-resolver"]


### PR DESCRIPTION
This PR makes a small change to how the `std` feature is defined in order to not depend on some crates by default if the associated crypto resolver isn't also enabled. Sorry I didn't notice this sooner during the `0.10` pre-releases, I didn't have a chance to try updating `snow` internally at the time.

Due to Cargo's default behavior when specifying crate features, [dependencies will become activated if another feature flag lists them](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features):
> The "package-name/feature-name" syntax will also enable package-name if it is an optional dependency. Often this is not what you want.

This change slipped in when https://github.com/mcginty/snow/pull/183 was merged and added `std` to `snow`'s default features. As `std` also depends on some crypto crates (in my case I noticed _ring_), those will be implicitly activated too. Note that they will still show up in the lockfile due to https://github.com/rust-lang/cargo/issues/10801, but they won't be compiled after this PR.

As far as I know this is not a breaking change.

I tested this with a local `cargo` project that depends on nothing other then `snow`.

<details>

<summary>Before:</summary>

```
cargo build
   Compiling typenum v1.18.0
   Compiling version_check v0.9.5
   Compiling cfg-if v1.0.1
   Compiling libc v0.2.174
   Compiling subtle v2.6.1
   Compiling semver v1.0.26
   Compiling zeroize v1.8.1
   Compiling shlex v1.3.0
   Compiling opaque-debug v0.3.1
   Compiling getrandom v0.3.3
   Compiling untrusted v0.9.0
   Compiling cc v1.2.30
   Compiling generic-array v0.14.7
   Compiling ring v0.17.14
   Compiling cpufeatures v0.2.17
   Compiling getrandom v0.2.16
   Compiling rustc_version v0.4.1
   Compiling curve25519-dalek v4.1.3
   Compiling snow v0.10.0
   Compiling crypto-common v0.1.6
   Compiling inout v0.1.4
   Compiling block-buffer v0.10.4
   Compiling universal-hash v0.5.1
   Compiling aead v0.5.2
   Compiling cipher v0.4.4
   Compiling digest v0.10.7
   Compiling polyval v0.6.2
   Compiling poly1305 v0.8.0
   Compiling sha2 v0.10.9
   Compiling blake2 v0.10.6
   Compiling chacha20 v0.9.1
   Compiling aes v0.8.4
   Compiling ctr v0.9.2
   Compiling ghash v0.5.1
   Compiling chacha20poly1305 v0.10.1
   Compiling aes-gcm v0.10.3
   Compiling snow-features-test v0.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.79s
```

</details>

<details>

<summary>After:</summary>

```
cargo build
   Compiling typenum v1.18.0
   Compiling version_check v0.9.5
   Compiling subtle v2.6.1
   Compiling cfg-if v1.0.1
   Compiling libc v0.2.174
   Compiling semver v1.0.26
   Compiling zeroize v1.8.1
   Compiling opaque-debug v0.3.1
   Compiling getrandom v0.3.3
   Compiling generic-array v0.14.7
   Compiling rustc_version v0.4.1
   Compiling curve25519-dalek v4.1.3
   Compiling snow v0.10.0 (/Users/User/dev/github/snow)
   Compiling cpufeatures v0.2.17
   Compiling crypto-common v0.1.6
   Compiling inout v0.1.4
   Compiling block-buffer v0.10.4
   Compiling universal-hash v0.5.1
   Compiling aead v0.5.2
   Compiling cipher v0.4.4
   Compiling digest v0.10.7
   Compiling polyval v0.6.2
   Compiling poly1305 v0.8.0
   Compiling blake2 v0.10.6
   Compiling sha2 v0.10.9
   Compiling chacha20 v0.9.1
   Compiling ctr v0.9.2
   Compiling aes v0.8.4
   Compiling ghash v0.5.1
   Compiling chacha20poly1305 v0.10.1
   Compiling aes-gcm v0.10.3
   Compiling snow-features-test v0.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.13s
```

</details>


